### PR TITLE
Handle validation errors on ubusCall

### DIFF
--- a/src/lib/standalone/ubus.ts
+++ b/src/lib/standalone/ubus.ts
@@ -4,20 +4,55 @@
 import axios from 'axios'
 import { getStandaloneApiEndpoint } from '../config'
 import { useLoginStore } from '@/stores/standalone/standaloneLogin'
+import { MessageBag } from '../validation'
+
+type ValidationError = {
+  message: string
+  parameter: string
+  value: string
+}
+
+export class NeValidationError extends Error {
+  errorBag: MessageBag
+
+  constructor(message: string, errorBag: MessageBag) {
+    super(message)
+    this.name = this.constructor.name
+    this.errorBag = errorBag
+  }
+}
 
 export const ubusCall = async (path: string, method: any, payload: any = {}) => {
   const loginStore = useLoginStore()
 
-  const res = await axios.post(
-    `${getStandaloneApiEndpoint()}/ubus/call`,
-    { path, method, payload },
-    {
-      headers: {
-        Authorization: `Bearer ${loginStore.token}`
+  try {
+    const res = await axios.post(
+      `${getStandaloneApiEndpoint()}/ubus/call`,
+      { path, method, payload },
+      {
+        headers: {
+          Authorization: `Bearer ${loginStore.token}`
+        }
       }
+    )
+    return res.data
+  } catch (err: any) {
+    const validationErrors = err.response?.data?.data?.validation?.errors
+
+    if (validationErrors?.length) {
+      // it's an error validation
+      const errorBag = new MessageBag()
+      validationErrors.forEach((validationError: ValidationError) => {
+        const errorMessages = errorBag.get(validationError.parameter) || []
+        errorMessages.push(validationError.message)
+        errorBag.set(validationError.parameter, errorMessages)
+      })
+      throw new NeValidationError(err.response.data.message, errorBag)
+    } else {
+      // rethrow the error as-is
+      throw err
     }
-  )
-  return res.data
+  }
 }
 
 export const getUciConfig = async (config: string) => {

--- a/src/lib/standalone/ubus.ts
+++ b/src/lib/standalone/ubus.ts
@@ -6,13 +6,7 @@ import { getStandaloneApiEndpoint } from '../config'
 import { useLoginStore } from '@/stores/standalone/standaloneLogin'
 import { MessageBag } from '../validation'
 
-type ValidationError = {
-  message: string
-  parameter: string
-  value: string
-}
-
-export class NeValidationError extends Error {
+export class ValidationError extends Error {
   errorBag: MessageBag
 
   constructor(message: string, errorBag: MessageBag) {
@@ -42,12 +36,12 @@ export const ubusCall = async (path: string, method: any, payload: any = {}) => 
     if (validationErrors?.length) {
       // it's an error validation
       const errorBag = new MessageBag()
-      validationErrors.forEach((validationError: ValidationError) => {
+      validationErrors.forEach((validationError: any) => {
         const errorMessages = errorBag.get(validationError.parameter) || []
         errorMessages.push(validationError.message)
         errorBag.set(validationError.parameter, errorMessages)
       })
-      throw new NeValidationError(err.response.data.message, errorBag)
+      throw new ValidationError(err.response.data.message, errorBag)
     } else {
       // rethrow the error as-is
       throw err


### PR DESCRIPTION
Detect validation errors while invoking `/ubus/call` and throw a `NeValidationError` to properly handle the error validations on the UI.

See: https://github.com/NethServer/nethsecurity/pull/163