### PR TITLE
Port forward: ui fixes and better error handling

### DIFF
--- a/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
+++ b/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
@@ -165,6 +165,11 @@ watchEffect(() => {
 })
 
 function close() {
+  error.value.notificationTitle = ''
+  error.value.notificationDescription = ''
+  validationErrorBag.value.clear()
+  restrictIPValidationErrors.value = []
+
   resetForm()
   emit('close')
 }

--- a/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
+++ b/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
@@ -171,7 +171,9 @@ function close() {
 
 onMounted(() => {
   fetchOptions()
-  firewallConfig.fetch()
+  if (firewallConfig.loading || firewallConfig.error) {
+    firewallConfig.fetch()
+  }
 })
 
 function resetRestrictIPValidationErrors() {
@@ -286,13 +288,17 @@ async function createOrEditPortForward() {
     "
   >
     <NeInlineNotification
-      v-if="error.notificationTitle"
-      :title="error.notificationTitle"
-      :description="error.notificationDescription"
+      v-if="error.notificationTitle || firewallConfig.error"
+      :title="firewallConfig.error ? t('error.cannot_retrieve_zones') : error.notificationTitle"
+      :description="
+        firewallConfig.error
+          ? t(getAxiosErrorMessage(firewallConfig.error))
+          : error.notificationDescription
+      "
       class="mb-6"
       kind="error"
     />
-    <NeSkeleton v-if="loading || firewallConfig.loading" :lines="10" />
+    <NeSkeleton v-if="loading || firewallConfig.loading || firewallConfig.error" :lines="10" />
     <div v-else class="flex flex-col gap-y-6">
       <NeToggle :label="t('standalone.port_forward.status')" v-model="enabled" />
       <NeTextInput

--- a/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
+++ b/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
@@ -327,13 +327,6 @@ async function createOrEditPortForward() {
           ></template
         >
       </NeTextInput>
-      <NeCombobox
-        :label="t('standalone.port_forward.destination_zone')"
-        :placeholder="t('standalone.port_forward.choose_zone')"
-        :options="supportedDestinationZones"
-        :selected-label="t('standalone.port_forward.any_zone')"
-        v-model="destinationZone"
-      />
       <NeTextInput
         :label="t('standalone.port_forward.destination_port')"
         v-model="destinationPort"
@@ -354,11 +347,17 @@ async function createOrEditPortForward() {
       </div>
       <template v-if="showAdvancedSettings">
         <NeCombobox
+          :label="t('standalone.port_forward.destination_zone')"
+          :placeholder="t('standalone.port_forward.choose_zone')"
+          :options="supportedDestinationZones"
+          :selected-label="t('standalone.port_forward.any_zone')"
+          v-model="destinationZone"
+        />
+        <NeCombobox
           :label="t('standalone.port_forward.wan_ip')"
           :options="wanInterfaces"
           v-model="wan"
         />
-
         <NeMultiTextInput
           :title="t('standalone.port_forward.restrict_access_to')"
           :optional="true"

--- a/src/views/standalone/firewall/PortForward.vue
+++ b/src/views/standalone/firewall/PortForward.vue
@@ -6,7 +6,8 @@ import {
   NeButton,
   NeTextInput,
   NeSkeleton,
-  NeInlineNotification
+  NeInlineNotification,
+  NeEmptyState
 } from '@nethserver/vue-tailwind-lib'
 import PortForwardTable from '@/components/standalone/firewall/PortForwardTable.vue'
 import { onMounted, ref } from 'vue'
@@ -204,14 +205,11 @@ onMounted(() => {
     />
     <NeSkeleton v-if="loading" :lines="10" />
     <template v-else>
-      <div
+      <NeEmptyState
+        :title="t('standalone.port_forward.no_port_forward_configured')"
+        :icon="['fas', 'circle-info']"
         v-if="Object.keys(portForwards).length == 0"
-        class="flex flex-col items-center justify-center rounded-md p-10 dark:bg-gray-800"
-      >
-        <p class="mb-4 text-sm">
-          <strong>{{ t('standalone.port_forward.no_port_forward_configured') }}</strong>
-        </p>
-        <NeButton kind="primary" @click="openCreateEditDrawer(null)"
+        ><NeButton kind="primary" @click="openCreateEditDrawer(null)"
           ><template #prefix>
             <font-awesome-icon
               :icon="['fas', 'circle-plus']"
@@ -219,19 +217,14 @@ onMounted(() => {
               aria-hidden="true"
             /> </template
           >{{ t('standalone.port_forward.add_port_forward') }}</NeButton
-        >
-      </div>
-      <div
-        v-else-if="Object.keys(filteredPortForwards).length == 0"
-        class="flex flex-col items-center justify-center rounded-md p-10 dark:bg-gray-800"
+        ></NeEmptyState
       >
-        <p class="mb-4 text-sm">
-          <strong>{{ t('standalone.port_forward.no_port_forward_found') }}</strong>
-        </p>
-        <p class="text-sm">
-          {{ t('standalone.port_forward.filter_change_suggestion') }}
-        </p>
-      </div>
+      <NeEmptyState
+        :title="t('standalone.port_forward.no_port_forward_found')"
+        :description="t('standalone.port_forward.filter_change_suggestion')"
+        :icon="['fas', 'circle-info']"
+        v-else-if="Object.keys(filteredPortForwards).length == 0"
+      />
       <PortForwardTable
         v-else
         v-for="(portForward, key) in filteredPortForwards"


### PR DESCRIPTION
- add error handling for fetching firewall config inside CreateOrEditPortForwardDrawer
- move destination zone combobox inside advanced settings in CreateOrEditPortForwardDrawer
- replace empty cards in PortForward page with NeEmptyState
- clear errors when exiting CreateOrEditPortForwardDrawer