### PR TITLE
feat: added logs view

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -564,7 +564,14 @@
       "title": "VPN"
     },
     "logs": {
-      "title": "Logs"
+      "title": "Logs",
+      "limit_rows": "Lines limit",
+      "wrap_row": "Wrap lines",
+      "search": "Search",
+      "search_placeholder": "Search logs",
+      "pooling": "Follow logs",
+      "search_error": "Invalid regular expression.",
+      "search_tooltip": "The search uses regular expression format."
     },
     "report": {
       "title": "Report"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -64,6 +64,11 @@ const standaloneRoutes = [
     path: 'firewall/port-forward',
     name: 'PortForward',
     component: () => import('../views/standalone/firewall/PortForward.vue')
+  },
+  {
+    path: 'logs',
+    name: 'Logs',
+    component: () => import('../views/standalone/LogsView.vue')
   }
 ]
 

--- a/src/views/standalone/LogsView.vue
+++ b/src/views/standalone/LogsView.vue
@@ -1,0 +1,184 @@
+<script lang="ts" setup>
+import type { NeComboboxOption } from '@nethserver/vue-tailwind-lib'
+import {
+  getAxiosErrorMessage,
+  NeCombobox,
+  NeInlineNotification,
+  NeTextInput,
+  NeTitle,
+  NeToggle,
+  NeTooltip
+} from '@nethserver/vue-tailwind-lib'
+import { useI18n } from 'vue-i18n'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { ubusCall, ValidationError } from '@/lib/standalone/ubus'
+import type { AxiosResponse } from 'axios'
+import { MessageBag } from '@/lib/validation'
+
+interface LogResponse {
+  values: string[]
+}
+
+const logLimitComboboxOption: NeComboboxOption[] = [
+  {
+    id: '100',
+    label: '100'
+  },
+  {
+    id: '200',
+    label: '200'
+  },
+  {
+    id: '500',
+    label: '500'
+  },
+  {
+    id: '1000',
+    label: '1000'
+  }
+]
+
+const { t } = useI18n()
+
+const limit = ref(logLimitComboboxOption[0].id)
+const wrapRow = ref(true)
+const search = ref('')
+const pool = ref(false)
+const poolInterval = ref<number>()
+const errorBag = ref(new MessageBag())
+
+const logRef = ref<HTMLUListElement | null>(null)
+
+const data = ref<Array<string>>()
+const error = ref<Error>()
+const loading = ref(false)
+
+const logRowStyle = computed(() => {
+  return wrapRow.value ? 'break-all' : 'whitespace-nowrap'
+})
+
+watch(data, () => {
+  setTimeout(() => {
+    if (logRef.value != null) {
+      logRef.value.scrollTop = logRef.value.scrollHeight
+    }
+  }, 50)
+})
+
+watch([limit, search], () => {
+  fetchData()
+})
+
+watch(pool, () => {
+  if (pool.value) {
+    fetchData()
+    poolInterval.value = setInterval(() => {
+      fetchData()
+    }, 2500)
+  } else {
+    clearInterval(poolInterval.value)
+  }
+})
+
+onMounted(() => {
+  fetchData()
+})
+
+onUnmounted(() => {
+  if (poolInterval.value) {
+    clearInterval(poolInterval.value)
+  }
+})
+
+function fetchData() {
+  // reset status
+  error.value = undefined
+  errorBag.value.clear()
+  loading.value = true
+  // api call
+  ubusCall('ns.log', 'get-log', {
+    search: search.value,
+    limit: limit.value
+  })
+    .then((response: AxiosResponse<LogResponse>) => {
+      // please don't call the RegExp with an empty string, it appears to hang the system way longer than it should
+      // this STILL IS NOT a feasible solution due to the task inefficiency, but it's better than nothing
+      // TODO: defer loading and don't lock the interface
+      if (search.value == '') {
+        data.value = response.data.values
+      } else {
+        const regExStr = new RegExp(search.value, 'g')
+        data.value = response.data.values.map((entry) => {
+          return entry.replace(
+            regExStr,
+            (match) => `<span class="dark:bg-yellow-800 bg-yellow-400">${match}</span>`
+          )
+        })
+      }
+    })
+    .catch((reason: Error) => {
+      if (reason instanceof ValidationError) {
+        if (reason.errorBag.has('search')) {
+          errorBag.value.set('search', t('standalone.logs.search_error'))
+        }
+        if (reason.errorBag.has('limit')) {
+          errorBag.value.set('limit', t('standalone.logs.limit_error'))
+        }
+      } else {
+        // generic error, show in UI
+        error.value = reason
+      }
+    })
+    .finally(() => (loading.value = false))
+}
+</script>
+
+<template>
+  <NeTitle>{{ t('standalone.logs.title') }}</NeTitle>
+  <div class="space-y-8">
+    <div class="grid grid-cols-1 gap-6 sm:max-w-xl sm:grid-cols-2">
+      <NeTextInput
+        v-model="search"
+        :invalid-message="errorBag.getFirstFor('search')"
+        :label="t('standalone.logs.search')"
+        :placeholder="t('standalone.logs.search_placeholder')"
+      >
+        <template #tooltip>
+          <NeTooltip>
+            <template #content>
+              {{ t('standalone.logs.search_tooltip') }}
+            </template>
+          </NeTooltip>
+        </template>
+      </NeTextInput>
+      <NeCombobox
+        v-model="limit"
+        :invalid-message="errorBag.getFirstFor('limits')"
+        :label="t('standalone.logs.limit_rows')"
+        :options="logLimitComboboxOption"
+      />
+      <div class="col-span-1 flex gap-8 sm:col-span-2">
+        <NeToggle v-model="wrapRow" :label="t('standalone.logs.wrap_row')" />
+        <NeToggle v-model="pool" :label="t('standalone.logs.pooling')" />
+      </div>
+    </div>
+    <NeInlineNotification
+      v-if="error"
+      :description="error.message"
+      :title="t(getAxiosErrorMessage(error))"
+      kind="error"
+    />
+    <ul
+      ref="logRef"
+      class="max-h-[55vh] max-w-6xl divide-y divide-gray-300 overflow-y-scroll rounded-md border border-gray-300 font-mono text-sm dark:divide-gray-600 dark:border-gray-600"
+    >
+      <li
+        v-for="(entry, index) in data"
+        :key="index"
+        :class="logRowStyle"
+        class="p-2 odd:bg-gray-100 odd:dark:bg-gray-950"
+        v-html="entry"
+      ></li>
+    </ul>
+  </div>
+</template>


### PR DESCRIPTION
~~Currently evaluating what can be done to highlight the searched text in the UI, the solution found is highly inefficient and hence not included in PR, [just commented out in the code](https://github.com/NethServer/nethsecurity-ui/pull/61/files#diff-a97c9a3ab6a48c6bca4def6c506ac9489cf97a8f9c7f1c56e97d1ac1a48ba190R100).~~

I appears that if an empty regex is given, it loads too much the task. Why? No clue.

Added cards for TODOs: 
- https://trello.com/c/czrHLZqn/147-uilogs-add-loading-placeholders
- https://trello.com/c/xJl5sGQR/148-uilogs-add-less-expensive-search-highlight