### PR TITLE
build: added husky missing hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint --ignore-path .gitignore --fix .",
     "lint:check": "eslint --ignore-path .gitignore --fix-dry-run .",
     "format": "prettier --write .",
-    "format:check": "prettier --list-different ."
+    "format:check": "prettier --list-different .",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.0",


### PR DESCRIPTION
Due to unknown issues, `husky` hook was missing from `package.json`
