### PR TITLE
Port forward: fix minor ui issues

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -664,7 +664,6 @@
       "any": "Any",
       "destination_address_tooltip": "Redirect matched incoming traffic to the specified internal host.",
       "restrict_access_to_tooltip": "By default, the port forward access is granted to anyone. Add IPs or CIDRs to restric the access only from the given networks.",
-      "no_port_forward_configured": "No port forward configured",
       "no_port_forward_found": "No port forward found",
       "filter_change_suggestion": "Try changing filter value",
       "copy": "Copy"

--- a/public/i18n/it/translation.json
+++ b/public/i18n/it/translation.json
@@ -541,7 +541,6 @@
       "wan_ip": "IP WAN",
       "destination_port": "Porta di destinazione",
       "add_port_forward": "Aggiungi port forward",
-      "no_port_forward_configured": "Nessun port forward configurato",
       "destination_zone": "Zona di destinazione",
       "restrict_access_to_tooltip": "Di default, l'accesso al port forward è consentito a chiunque. Aggiungi indirizzi IP o CIDR per limitare l'accesso solo alle reti indicate",
       "disabled": "Disabilitato",

--- a/src/components/standalone/FilterableListItemLayout.vue
+++ b/src/components/standalone/FilterableListItemLayout.vue
@@ -92,7 +92,11 @@ onMounted(() => {
         {{ description }}
       </p>
       <div class="ml-2 shrink-0">
-        <NeButton kind="secondary" @click="openCreateEditDrawer(null)" v-if="!readonly">
+        <NeButton
+          kind="secondary"
+          @click="openCreateEditDrawer(null)"
+          v-if="!readonly && items.length > 0"
+        >
           <template #prefix>
             <font-awesome-icon :icon="['fas', 'circle-plus']" class="h-4 w-4" aria-hidden="true" />
           </template>

--- a/src/components/standalone/NeMultiTextInput.vue
+++ b/src/components/standalone/NeMultiTextInput.vue
@@ -104,14 +104,14 @@ onMounted(() => {
 
 <template>
   <div>
-    <div v-if="title" class="mb-4 flex items-end justify-between">
+    <div v-if="title" class="mb-4 flex items-center justify-between">
       <div>
         <span class="mr-2 text-sm font-medium leading-6 text-gray-700 dark:text-gray-200">
           {{ title }}
         </span>
         <slot name="tooltip"></slot>
       </div>
-      <span v-if="optional" class="ml-2 font-normal">{{ optionalLabel }}</span>
+      <span v-if="optional" class="ml-2 text-sm font-normal">{{ optionalLabel }}</span>
     </div>
 
     <div class="space-y-6">

--- a/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
+++ b/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
@@ -9,6 +9,7 @@ import {
   NeSkeleton,
   NeInlineNotification,
   NeTooltip,
+  NeFormItemLabel,
   type NeComboboxOption,
   getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'
@@ -317,7 +318,15 @@ async function createOrEditPortForward() {
     />
     <NeSkeleton v-if="loading || firewallConfig.loading" :lines="10" />
     <div v-else-if="!firewallConfig.error" class="flex flex-col gap-y-6">
-      <NeToggle :label="t('standalone.port_forward.status')" v-model="enabled" />
+      <div>
+        <NeFormItemLabel>{{ t('standalone.port_forward.status') }}</NeFormItemLabel>
+        <NeToggle
+          :label="
+            enabled ? t('standalone.port_forward.enabled') : t('standalone.port_forward.disabled')
+          "
+          v-model="enabled"
+        />
+      </div>
       <NeTextInput
         :label="t('standalone.port_forward.name')"
         v-model="name"
@@ -398,9 +407,26 @@ async function createOrEditPortForward() {
             >
           </template>
         </NeMultiTextInput>
-
-        <NeToggle :label="t('standalone.port_forward.log')" v-model="log" />
-        <NeToggle :label="t('standalone.port_forward.hairpin_nat')" v-model="reflection" />
+        <div>
+          <NeFormItemLabel>{{ t('standalone.port_forward.log') }}</NeFormItemLabel>
+          <NeToggle
+            :label="
+              log ? t('standalone.port_forward.enabled') : t('standalone.port_forward.disabled')
+            "
+            v-model="log"
+          />
+        </div>
+        <div>
+          <NeFormItemLabel>{{ t('standalone.port_forward.hairpin_nat') }}</NeFormItemLabel>
+          <NeToggle
+            :label="
+              reflection
+                ? t('standalone.port_forward.enabled')
+                : t('standalone.port_forward.disabled')
+            "
+            v-model="reflection"
+          />
+        </div>
         <NeCombobox
           v-if="reflection"
           :label="t('standalone.port_forward.hairpin_nat_zones')"

--- a/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
+++ b/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
@@ -77,8 +77,8 @@ const sourcePort = ref('')
 const destinationIP = ref('')
 const destinationPort = ref('')
 const wan = ref('')
-const enabled = ref(false)
-const restrict = ref<string[]>([])
+const enabled = ref(true)
+const restrict = ref<string[]>([''])
 const protocols = ref<NeComboboxOption[]>([])
 const log = ref(false)
 const reflection = ref(false)
@@ -94,8 +94,11 @@ function resetForm() {
   destinationIP.value = props.initialItem?.dest_ip ?? ''
   destinationPort.value = props.initialItem?.destination_port ?? ''
   wan.value = props.initialItem?.wan ?? 'any'
-  enabled.value = props.initialItem?.enabled ?? false
-  restrict.value = props.initialItem?.restrict.map((x) => x) ?? []
+  enabled.value = props.initialItem?.enabled ?? true
+  restrict.value =
+    props.initialItem?.restrict && props.initialItem.restrict.length > 0
+      ? props.initialItem?.restrict.map((x) => x)
+      : ['']
   protocols.value =
     props.initialItem?.protocol.map((proto: string) => ({
       id: proto,
@@ -169,6 +172,7 @@ function close() {
   error.value.notificationDescription = ''
   validationErrorBag.value.clear()
   restrictIPValidationErrors.value = []
+  showAdvancedSettings.value = false
 
   resetForm()
   emit('close')
@@ -210,7 +214,8 @@ function validate(): boolean {
 
   let validRestrict = true
   for (let [index, restrictValue] of restrict.value.entries()) {
-    for (let validator of [validateRequired(restrictValue), validateIpAddress(restrictValue)]) {
+    if (restrictValue) {
+      let validator = validateIpAddress(restrictValue)
       if (!validator.valid) {
         restrictIPValidationErrors.value[index] = t(validator.errMessage as string)
         validRestrict = false
@@ -265,7 +270,7 @@ async function createOrEditPortForward() {
         enabled: enabled.value ? '1' : '0',
         log: log.value ? '1' : '0',
         reflection: reflection.value ? '1' : '0',
-        restrict: restrict.value,
+        restrict: restrict.value.filter((x) => x != ''),
         dest: destinationZone.value === 'any' ? '' : destinationZone.value,
         reflection_zone: reflectionZones.value.map((reflectionZone) => reflectionZone.id)
       }

--- a/src/views/standalone/firewall/PortForward.vue
+++ b/src/views/standalone/firewall/PortForward.vue
@@ -210,7 +210,7 @@ onMounted(() => {
     <NeSkeleton v-if="loading" :lines="10" />
     <template v-else>
       <NeEmptyState
-        :title="t('standalone.port_forward.no_port_forward_configured')"
+        :title="t('standalone.port_forward.no_port_forward_found')"
         :icon="['fas', 'circle-info']"
         v-if="Object.keys(portForwards).length == 0"
         ><NeButton kind="primary" @click="openCreateEditDrawer(null)"

--- a/src/views/standalone/firewall/PortForward.vue
+++ b/src/views/standalone/firewall/PortForward.vue
@@ -183,8 +183,12 @@ onMounted(() => {
       <p class="max-w-2xl text-sm font-normal text-gray-500 dark:text-gray-400">
         {{ t('standalone.port_forward.description') }}
       </p>
-      <div>
-        <NeButton kind="secondary" @click="openCreateEditDrawer(null)">
+      <div class="ml-2 shrink-0">
+        <NeButton
+          kind="secondary"
+          @click="openCreateEditDrawer(null)"
+          v-if="Object.keys(portForwards).length > 0"
+        >
           <template #prefix>
             <font-awesome-icon :icon="['fas', 'circle-plus']" class="h-4 w-4" aria-hidden="true" />
           </template>


### PR DESCRIPTION
- update translation in NeEmptyState when no port forward is found
- show separate label on toggles in the add/edit port forward drawer
- hide add button from description when no items are present in PortForward view and FilterableListItemLayout
- enable port forward toggle by default when adding
- hide advanced settings when drawer is closed
- fix optional label size in NeMultiTextInput
- show a text input for the restrict ip NeMultiTextInput by default
- remove the restrict ip required validator: empty items are filtered out on add/edit request, ip validation is performed only on filled textinputs