### PR TITLE
fix(settings): remove sync with browser button

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -289,7 +289,6 @@
       "notes_placeholder": "Notes about this unit",
       "local_time": "Local time",
       "timezone": "Timezone",
-      "sync_with_browser": "Sync with browser",
       "sync_with_ntp_server": "Sync with NTP server",
       "enable_ntp_client": "Enable NTP client",
       "provide_ntp_server": "Provide NTP server",

--- a/src/components/standalone/system_settings/GeneralSettings.vue
+++ b/src/components/standalone/system_settings/GeneralSettings.vue
@@ -291,14 +291,13 @@ async function syncWithNtpServer() {
             </div>
           </div>
           <!-- sync buttons -->
-          <div>
+          <div class="-ml-2.5">
             <NeButton
               @click="syncWithNtpServer"
               kind="tertiary"
               size="lg"
               :loading="loading.syncWithNtpServer"
               :disabled="loading.syncWithNtpServer || loading.save"
-              class="ml-4"
               >{{ t('standalone.system_settings.sync_with_ntp_server') }}</NeButton
             >
           </div>

--- a/src/components/standalone/system_settings/GeneralSettings.vue
+++ b/src/components/standalone/system_settings/GeneralSettings.vue
@@ -213,23 +213,6 @@ async function save() {
   }
 }
 
-async function syncWithBrowser() {
-  loading.value.syncWithBrowser = true
-  const browserTime = Math.floor(Date.now() / 1000)
-
-  try {
-    await ubusCall('luci', 'setLocaltime', {
-      localtime: browserTime
-    })
-    getSystemInfo()
-  } catch (err: any) {
-    console.error(err)
-    error.value.notificationTitle = t('error.cannot_sync_local_time')
-    error.value.notificationDescription = t(getAxiosErrorMessage(err))
-  }
-  loading.value.syncWithBrowser = false
-}
-
 async function syncWithNtpServer() {
   loading.value.syncWithNtpServer = true
 
@@ -309,15 +292,6 @@ async function syncWithNtpServer() {
           </div>
           <!-- sync buttons -->
           <div>
-            <NeButton
-              @click="syncWithBrowser"
-              kind="tertiary"
-              size="lg"
-              :loading="loading.syncWithBrowser"
-              :disabled="loading.syncWithBrowser || loading.save"
-              class="-ml-2.5"
-              >{{ t('standalone.system_settings.sync_with_browser') }}</NeButton
-            >
             <NeButton
               @click="syncWithNtpServer"
               kind="tertiary"


### PR DESCRIPTION
The button didn't work as expected: the
change to system configuration seems ignored
by ubus

Card: https://trello.com/c/BFutxOq0/198-ntp-time-is-wrong