### PR TITLE
fix: dhcp, show server validation error

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -166,7 +166,8 @@
     "cannot_set_update_schedule": "Cannot set update schedule",
     "cannot_upload_image": "Cannot upload image",
     "cannot_update_packages": "Cannot update packages",
-    "cannot_update_system": "Cannot update system"
+    "cannot_update_system": "Cannot update system",
+    "last_must_be_greater_than_first": "Ensure that the last IP in the range is greater than the first IP"
   },
   "ne_text_input": {
     "show_password": "Show password",


### PR DESCRIPTION
If the range is invalid, the server now raises a specific error. Before this change, the server validation was not visible.
![Screenshot from 2023-11-24 12-35-24](https://github.com/NethServer/nethsecurity-ui/assets/804596/7311a90b-eda5-471c-ac09-31c0f660e324)

Card: https://trello.com/c/dTaFNmqv/219-qa-dns-dhcp-various