### PR TITLE
Update: clear state when closing upload image drawer

### DIFF
--- a/src/components/standalone/update/UploadImageDrawer.vue
+++ b/src/components/standalone/update/UploadImageDrawer.vue
@@ -71,6 +71,9 @@ function close() {
   error.value.notificationDetails = ''
   fileInputValidationError.value = ''
   fileToUpload.value = null
+  isReadyToUpdate.value = false
+  isUploadingImage.value = false
+  uploadedImageFileName.value = ''
   emit('close')
 }
 


### PR DESCRIPTION
- Fix issue where state would not be cleared properly when closing the upload image drawer (after uploading a file)