### PR TITLE
fix: ssh, prevent default axios error

### DIFF
--- a/src/components/standalone/ssh/SshKeys.vue
+++ b/src/components/standalone/ssh/SshKeys.vue
@@ -25,7 +25,7 @@ type SshKeyError = {
 
 type SshKeysResponse = {
   data: {
-    data: string
+    keys: string
   }
 }
 
@@ -89,11 +89,11 @@ onMounted(() => {
 function load() {
   error.value = undefined
   loading.value = true
-  ubusCall('file', 'read', { path: '/etc/dropbear/authorized_keys' })
+  ubusCall('ns.ssh', 'list-keys')
     .then((response: SshKeysResponse) => {
       sshKeys.value = new Array<SshKey>()
       // the response will be a string with all the keys separated by a newline
-      response.data.data.split('\n').forEach((line) => {
+      response.data.keys.split('\n').forEach((line) => {
         // final end line, skipping
         if (line.length == 0) {
           return


### PR DESCRIPTION
If the authorized_keys file was empty, the UI was
displaying the error toast notification

Card: https://trello.com/c/ZymrMQnR/226-ssh-add-api-for-authorized-keys

See also: https://github.com/NethServer/nethsecurity/pull/241