### PR TITLE
feat(devices): read allowed zone from backend

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -199,7 +199,8 @@
     "cannot_edit_user": "Cannot edit user",
     "user_already_exists": "User already exists",
     "cannot_retrieve_ldap_defaults": "Cannot retrieve LDAP defaults",
-    "cannot_retrieve_users": "Cannot retrieve users"
+    "cannot_retrieve_users": "Cannot retrieve users",
+    "cannot_retrieve_zones_for_device_configuration": "Cannot retrieve zones for device configuration"
   },
   "ne_text_input": {
     "show_password": "Show password",

--- a/src/components/standalone/firewall/DeletePortForwardModal.vue
+++ b/src/components/standalone/firewall/DeletePortForwardModal.vue
@@ -2,7 +2,7 @@
 import { ubusCall } from '@/lib/standalone/ubus'
 import type { PortForward } from '@/views/standalone/firewall/PortForward.vue'
 import { NeModal, NeInlineNotification, getAxiosErrorMessage } from '@nethserver/vue-tailwind-lib'
-import { ref, toRefs } from 'vue'
+import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const props = defineProps<{

--- a/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
+++ b/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
@@ -113,7 +113,7 @@ let bondingPolicy = ref('balance-rr')
 let bondingPolicyRef = ref<HTMLDivElement | null>()
 let bondPrimaryDevice = ref('')
 let bondPrimaryDeviceRef = ref<HTMLDivElement | null>()
-let allowedZones = ref<any>([])
+let allowedZones = ref<Array<any>>([])
 
 let protocolBaseOptions = [
   {

--- a/src/views/standalone/network/InterfacesAndDevicesView.vue
+++ b/src/views/standalone/network/InterfacesAndDevicesView.vue
@@ -1123,7 +1123,6 @@ function isDeviceConfigurable(deviceOrIface: DeviceOrIface) {
       :device="currentDevice"
       :deviceType="deviceToConfigureType"
       :allDevices="allDevices"
-      :firewallConfig="firewallConfig"
       :networkConfig="networkConfig"
       :isShown="isShownConfigureDeviceDrawer"
       :interfaceToEdit="interfaceToEdit"


### PR DESCRIPTION
Read the list of zones that can be selected for device configuration from the backend, using `ns.devices list-zones-for-device-config` API.

See also: https://github.com/NethServer/nethsecurity/pull/254