### PR TITLE
feat: vpn tunnel, show connected flag

### DIFF
--- a/src/components/standalone/openvpn_tunnel/TunnelManager.vue
+++ b/src/components/standalone/openvpn_tunnel/TunnelManager.vue
@@ -26,6 +26,7 @@ export type ServerTunnel = {
   local_network: string[]
   remote_network: string[]
   vpn_network: string
+  connected: boolean
 }
 
 export type ClientTunnel = {
@@ -36,6 +37,7 @@ export type ClientTunnel = {
   port: string
   remote_host: string[]
   remote_network: string[]
+  connected: boolean
 }
 
 type Tunnel = ServerTunnel | ClientTunnel

--- a/src/components/standalone/openvpn_tunnel/TunnelTable.vue
+++ b/src/components/standalone/openvpn_tunnel/TunnelTable.vue
@@ -198,7 +198,11 @@ function getCellClasses(item: ServerTunnel | ClientTunnel) {
             'mr-2',
             'h-5',
             'w-5',
-            item.connected ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+            item.connected && item.enabled
+              ? 'text-green-600 dark:text-green-400'
+              : item.enabled
+              ? 'text-red-600 dark:text-red-400'
+              : ''
           ]"
           aria-hidden="true"
         />

--- a/src/components/standalone/openvpn_tunnel/TunnelTable.vue
+++ b/src/components/standalone/openvpn_tunnel/TunnelTable.vue
@@ -70,6 +70,10 @@ const tableHeaders = [
     key: 'status'
   },
   {
+    label: t('standalone.openvpn_tunnel.connection'),
+    key: 'connected'
+  },
+  {
     label: '',
     key: 'menu'
   }
@@ -182,6 +186,27 @@ function getCellClasses(item: ServerTunnel | ClientTunnel) {
             item.enabled
               ? t('standalone.openvpn_tunnel.enabled')
               : t('standalone.openvpn_tunnel.disabled')
+          }}
+        </p>
+      </div>
+    </template>
+    <template #connected="{ item }: { item: ServerTunnel | ClientTunnel }">
+      <div :class="['flex', 'flex-row', 'items-center', ...getCellClasses(item)]">
+        <font-awesome-icon
+          :icon="['fas', item.connected ? 'circle-check' : 'circle-xmark']"
+          :class="[
+            'mr-2',
+            'h-5',
+            'w-5',
+            item.connected ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+          ]"
+          aria-hidden="true"
+        />
+        <p>
+          {{
+            item.connected
+              ? t('standalone.openvpn_tunnel.connected')
+              : t('standalone.openvpn_tunnel.not_connected')
           }}
         </p>
       </div>


### PR DESCRIPTION
Card: https://trello.com/c/6wuSVOgb/211-openvpn-tunnel-missing-connected-disconnected-info

Tunnel enabled but not connected:
![Screenshot from 2023-12-21 07-39-21](https://github.com/NethServer/nethsecurity-ui/assets/804596/b8b4a42a-05e4-4a9b-a470-12883691511d)
Tunnel disabled and not connected:
![Screenshot from 2023-12-21 07-39-11](https://github.com/NethServer/nethsecurity-ui/assets/804596/c4c90cdb-2222-4f60-8dda-d9c229d6c792)
Tunnel enabled and connected:
![Screenshot from 2023-12-21 07-36-18](https://github.com/NethServer/nethsecurity-ui/assets/804596/55a550f9-8e99-4a0b-bd8c-6d97075e4233)


~~Requires: https://github.com/NethServer/nethsecurity/pull/247~~ Patch is already in main branch
