### PR TITLE
fix(openvpn): change compression param value

### DIFF
--- a/src/components/standalone/openvpn_rw/CreateOrEditRWServerDrawer.vue
+++ b/src/components/standalone/openvpn_rw/CreateOrEditRWServerDrawer.vue
@@ -92,8 +92,8 @@ const compressionOptions = [
     label: t('common.disabled')
   },
   {
-    id: 'lz0',
-    label: 'LZ0'
+    id: 'lzo',
+    label: 'LZO'
   },
   {
     id: 'lz4',

--- a/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
@@ -143,7 +143,7 @@ const compressionOptions = [
   },
   {
     id: 'lz0',
-    label: 'LZ0'
+    label: 'LZO'
   },
   {
     id: 'lz4',


### PR DESCRIPTION
Valid values are:
- empty
- lzo (not lz0)
- lz4