### PR TITLE
chore: import NeCombobox and NeBadge from vue-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nethesis/nethesis-brands-svg-icons": "github:nethesis/Font-Awesome#ns-brands",
         "@nethesis/nethesis-light-svg-icons": "github:nethesis/Font-Awesome#ns-light",
         "@nethesis/nethesis-solid-svg-icons": "github:nethesis/Font-Awesome#ns-solid",
+        "@nethesis/vue-components": "^0.5.0",
         "@nethserver/vue-tailwind-lib": "^0.1.1",
         "@types/lodash-es": "^4.17.12",
         "@vuepic/vue-datepicker": "^7.2.2",
@@ -1006,13 +1007,22 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.2.tgz",
-      "integrity": "sha512-gjYDSKv3TrM2sLTOKBc5rH9ckje8Wrwgx1CxAPbN5N3Fm4prfi7NsJVWd1jklp7i5uSCVwhZS5qlhMXqLrpAIg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.4.2"
+        "@fortawesome/fontawesome-common-types": "6.5.1"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
@@ -1284,6 +1294,43 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz",
       "integrity": "sha512-Sz07mnQrTekFWLz5BMjOzHl/+NooTdW8F8kDQxjWwbpOJcnoSg4vUDng8d/WR1wOxM0O+CY9Zw0nR054riNYtQ==",
       "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@nethesis/vue-components": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@nethesis/vue-components/-/vue-components-0.5.0.tgz",
+      "integrity": "sha512-QTdtOdxQtN5eZf/NlOPiy/YRRpgX3E7kfgdl8PXiKXZkgSwdCUCxs+eMapUTRbbJ2kxnmeIFAmnpUohuNoTkDg==",
+      "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.5.1",
+        "@fortawesome/free-solid-svg-icons": "^6.5.1",
+        "@fortawesome/vue-fontawesome": "^3.0.5",
+        "@headlessui/vue": "^1.7.16",
+        "@vueuse/core": "^10.7.0",
+        "lodash-es": "^4.17.21",
+        "uuid": "^9.0.1",
+        "vue": "^3.3.4",
+        "vue-tippy": "^6.3.1"
+      }
+    },
+    "node_modules/@nethesis/vue-components/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@nethesis/vue-components/node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -1909,13 +1956,13 @@
       }
     },
     "node_modules/@vueuse/core": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.6.1.tgz",
-      "integrity": "sha512-Pc26IJbqgC9VG1u6VY/xrXXfxD33hnvxBnKrLlA2LJlyHII+BSrRoTPJgGYq7qZOu61itITFUnm6QbacwZ4H8Q==",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.7.1.tgz",
+      "integrity": "sha512-74mWHlaesJSWGp1ihg76vAnfVq9NTv1YT0SYhAQ6zwFNdBkkP+CKKJmVOEHcdSnLXCXYiL5e7MaewblfiYLP7g==",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20",
-        "@vueuse/metadata": "10.6.1",
-        "@vueuse/shared": "10.6.1",
+        "@vueuse/metadata": "10.7.1",
+        "@vueuse/shared": "10.7.1",
         "vue-demi": ">=0.14.6"
       },
       "funding": {
@@ -1948,17 +1995,17 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.6.1.tgz",
-      "integrity": "sha512-qhdwPI65Bgcj23e5lpGfQsxcy0bMjCAsUGoXkJ7DsoeDUdasbZ2DBa4dinFCOER3lF4gwUv+UD2AlA11zdzMFw==",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.7.1.tgz",
+      "integrity": "sha512-jX8MbX5UX067DYVsbtrmKn6eG6KMcXxLRLlurGkZku5ZYT3vxgBjui2zajvUZ18QLIjrgBkFRsu7CqTAg18QFw==",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.6.1.tgz",
-      "integrity": "sha512-TECVDTIedFlL0NUfHWncf3zF9Gc4VfdxfQc8JFwoVZQmxpONhLxFrlm0eHQeidHj4rdTPL3KXJa0TZCk1wnc5Q==",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.7.1.tgz",
+      "integrity": "sha512-v0jbRR31LSgRY/C5i5X279A/WQjD6/JsMzGa+eqt658oJ75IvQXAeONmwvEMrvJQKnRElq/frzBR7fhmWY5uLw==",
       "dependencies": {
         "vue-demi": ">=0.14.6"
       },
@@ -6762,6 +6809,18 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@nethesis/nethesis-brands-svg-icons": "github:nethesis/Font-Awesome#ns-brands",
     "@nethesis/nethesis-light-svg-icons": "github:nethesis/Font-Awesome#ns-light",
     "@nethesis/nethesis-solid-svg-icons": "github:nethesis/Font-Awesome#ns-solid",
+    "@nethesis/vue-components": "^0.5.0",
     "@nethserver/vue-tailwind-lib": "^0.1.1",
     "@types/lodash-es": "^4.17.12",
     "@vuepic/vue-datepicker": "^7.2.2",

--- a/src/components/standalone/NeMultiTextInput.vue
+++ b/src/components/standalone/NeMultiTextInput.vue
@@ -6,19 +6,18 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { ref } from 'vue'
-import {
-  NeButton,
-  NeTextInput,
-  type NeComboboxOption,
-  NeCombobox
-} from '@nethserver/vue-tailwind-lib'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
+import { NeButton, NeTextInput } from '@nethserver/vue-tailwind-lib'
 import { watch } from 'vue'
 import { zip } from 'lodash-es'
+import { useI18n } from 'vue-i18n'
 
 export type KeyValueItem = {
   key: string
   value: string
 }
+
+const { t } = useI18n()
 
 const props = withDefaults(
   defineProps<{
@@ -131,10 +130,15 @@ onMounted(() => {
           <NeCombobox
             :options="keyOptions"
             :model-value="keys[i]"
-            @update:model-value="(e) => updateModelKey(i, e)"
+            @update:model-value="(e: any) => updateModelKey(i, e)"
             :invalid-message="invalidKeyMessages ? invalidKeyMessages[i] : ''"
             :placeholder="comboboxPlaceholder"
             v-if="useKeyCombobox"
+            :noResultsLabel="t('ne_combobox.no_results')"
+            :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+            :noOptionsLabel="t('ne_combobox.no_options_label')"
+            :selected-label="t('ne_combobox.selected')"
+            :user-input-label="t('ne_combobox.user_input_label')"
           />
           <NeTextInput
             :value="useKeyCombobox ? items[i] : items[i]"

--- a/src/components/standalone/backup_and_restore/MigrationDrawer.vue
+++ b/src/components/standalone/backup_and_restore/MigrationDrawer.vue
@@ -7,6 +7,7 @@
 import { onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ubusCall } from '@/lib/standalone/ubus'
+import { NeCombobox } from '@nethesis/vue-components'
 import {
   NeModal,
   NeTitle,
@@ -18,7 +19,6 @@ import {
   getAxiosErrorMessage,
   NeFormItemLabel,
   NeSkeleton,
-  NeCombobox,
   NeTextInput
 } from '@nethserver/vue-tailwind-lib'
 import { validateRequired } from '@/lib/validation'
@@ -289,6 +289,11 @@ function setMigrationTimer() {
                   :options="listDevices"
                   :invalid-message="errorMigration.devices[index]"
                   :ref="'deviceMigration' + index"
+                  :noResultsLabel="t('ne_combobox.no_results')"
+                  :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+                  :noOptionsLabel="t('ne_combobox.no_options_label')"
+                  :selected-label="t('ne_combobox.selected')"
+                  :user-input-label="t('ne_combobox.user_input_label')"
                 />
               </div>
             </div>

--- a/src/components/standalone/backup_and_restore/RestoreContent.vue
+++ b/src/components/standalone/backup_and_restore/RestoreContent.vue
@@ -7,12 +7,12 @@
 import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ubusCall } from '@/lib/standalone/ubus'
+import { NeCombobox } from '@nethesis/vue-components'
 import {
   NeModal,
   NeTitle,
   NeButton,
   NeTooltip,
-  NeCombobox,
   NeSkeleton,
   NeTextInput,
   NeFileInput,
@@ -297,6 +297,11 @@ function setRestoreTimer() {
               :options="listBackups"
               :label="t('standalone.backup_and_restore.restore.backup')"
               :invalid-message="errorRestore.backup"
+              :noResultsLabel="t('ne_combobox.no_results')"
+              :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+              :noOptionsLabel="t('ne_combobox.no_options_label')"
+              :selected-label="t('ne_combobox.selected')"
+              :user-input-label="t('ne_combobox.user_input_label')"
               class="grow"
               ref="backupRef"
             />

--- a/src/components/standalone/dashboard/ServiceCard.vue
+++ b/src/components/standalone/dashboard/ServiceCard.vue
@@ -5,9 +5,11 @@
 
 <script setup lang="ts">
 import { ubusCall } from '@/lib/standalone/ubus'
-import { NeCard, NeBadge, NeSkeleton, getAxiosErrorMessage } from '@nethserver/vue-tailwind-lib'
+import { NeBadge } from '@nethesis/vue-components'
+import { NeCard, NeSkeleton, getAxiosErrorMessage } from '@nethserver/vue-tailwind-lib'
 import { onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { faCheck, faWarning, faXmark } from '@fortawesome/free-solid-svg-icons'
 
 const props = defineProps({
   serviceName: { type: String },
@@ -134,13 +136,13 @@ function getBadgeText(status: string) {
 function getBadgeIcon(status: string) {
   switch (status) {
     case 'ok':
-      return ['fas', 'check']
+      return faCheck
     case 'warning':
-      return ['fas', 'warning']
+      return faWarning
     case 'disabled':
-      return ['fas', 'xmark']
+      return faXmark
     default:
-      return ['fas', 'xmark']
+      return faXmark
   }
 }
 </script>

--- a/src/components/standalone/dashboard/WanTrafficCard.vue
+++ b/src/components/standalone/dashboard/WanTrafficCard.vue
@@ -9,8 +9,8 @@ import { CYAN_500, CYAN_600, INDIGO_400, INDIGO_600 } from '@/lib/color'
 import { ubusCall } from '@/lib/standalone/ubus'
 import { useLoginStore } from '@/stores/standalone/standaloneLogin'
 import { useThemeStore } from '@/stores/theme'
+import { NeCombobox } from '@nethesis/vue-components'
 import {
-  NeCombobox,
   NeSkeleton,
   NeCard,
   getAxiosErrorMessage,
@@ -164,9 +164,12 @@ async function getInterfaceTraffic() {
       <NeCombobox
         v-model="selectedDevice"
         :options="wanOptions"
+        :disabled="loading.listWans || loading.getInterfaceTraffic"
         :noResultsLabel="t('ne_combobox.no_results')"
         :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
-        :disabled="loading.listWans || loading.getInterfaceTraffic"
+        :noOptionsLabel="t('ne_combobox.no_options_label')"
+        :selected-label="t('ne_combobox.selected')"
+        :user-input-label="t('ne_combobox.user_input_label')"
         class="mb-4"
       />
       <NeSkeleton v-if="loading.getInterfaceTraffic" :lines="6"></NeSkeleton>

--- a/src/components/standalone/dns_dhcp/DhcpManager.vue
+++ b/src/components/standalone/dns_dhcp/DhcpManager.vue
@@ -5,12 +5,12 @@
 
 <script setup lang="ts">
 import { ubusCall } from '@/lib/standalone/ubus'
+import { NeBadge } from '@nethesis/vue-components'
 import {
   getAxiosErrorMessage,
   NeInlineNotification,
   NeSkeleton,
   NeTitle,
-  NeBadge,
   NeButton,
   NeEmptyState
 } from '@nethserver/vue-tailwind-lib'

--- a/src/components/standalone/dns_dhcp/EditDhcpInterfaceDrawer.vue
+++ b/src/components/standalone/dns_dhcp/EditDhcpInterfaceDrawer.vue
@@ -13,6 +13,7 @@ import {
   type validationOutput
 } from '@/lib/validation'
 import { watchEffect } from 'vue'
+import { type NeComboboxOption } from '@nethesis/vue-components'
 import {
   NeSideDrawer,
   NeInlineNotification,
@@ -21,8 +22,7 @@ import {
   NeButton,
   NeSkeleton,
   NeTooltip,
-  getAxiosErrorMessage,
-  type NeComboboxOption
+  getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'
 import NeMultiTextInput, { type KeyValueItem } from '../NeMultiTextInput.vue'
 import { useI18n } from 'vue-i18n'

--- a/src/components/standalone/dpi/ManageDpiRuleModal.vue
+++ b/src/components/standalone/dpi/ManageDpiRuleModal.vue
@@ -12,13 +12,12 @@ import {
   getAppIcon
 } from '@/lib/standalone/dpi'
 import { ubusCall } from '@/lib/standalone/ubus'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   NeModal,
   NeInlineNotification,
   NeToggle,
   NeTextInput,
-  NeCombobox,
-  type NeComboboxOption,
   NeTooltip,
   NeCard,
   NeButton,
@@ -481,6 +480,8 @@ function onChange(ev: any, app: DpiAppOrProtocol) {
         :noResultsLabel="t('ne_combobox.no_results')"
         :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
         :noOptionsLabel="t('standalone.dpi.no_interfaces_available')"
+        :selected-label="t('ne_combobox.selected')"
+        :user-input-label="t('ne_combobox.user_input_label')"
         class="max-w-xs"
         ref="interfaceRef"
       >

--- a/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
+++ b/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
@@ -5,17 +5,16 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   NeSideDrawer,
   NeToggle,
   NeTextInput,
-  NeCombobox,
   NeButton,
   NeSkeleton,
   NeInlineNotification,
   NeTooltip,
   NeFormItemLabel,
-  type NeComboboxOption,
   getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'
 import { toRefs, ref, watch } from 'vue'
@@ -358,6 +357,11 @@ async function createOrEditPortForward() {
         :options="supportedProtocols"
         v-model="protocols"
         :invalid-message="validationErrorBag.getFirstFor('protocols')"
+        :noResultsLabel="t('ne_combobox.no_results')"
+        :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+        :noOptionsLabel="t('ne_combobox.no_options_label')"
+        :selected-label="t('ne_combobox.selected')"
+        :user-input-label="t('ne_combobox.user_input_label')"
       />
       <NeTextInput
         :label="t('standalone.port_forward.source_port')"
@@ -401,13 +405,22 @@ async function createOrEditPortForward() {
           :label="t('standalone.port_forward.destination_zone')"
           :placeholder="t('standalone.port_forward.choose_zone')"
           :options="supportedDestinationZones"
-          :selected-label="t('standalone.port_forward.any_zone')"
           v-model="destinationZone"
+          :noResultsLabel="t('ne_combobox.no_results')"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :noOptionsLabel="t('ne_combobox.no_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeCombobox
           :label="t('standalone.port_forward.wan_ip')"
           :options="wanInterfaces"
           v-model="wan"
+          :noResultsLabel="t('ne_combobox.no_results')"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :noOptionsLabel="t('ne_combobox.no_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeMultiTextInput
           :title="t('standalone.port_forward.restrict_access_to')"
@@ -454,6 +467,11 @@ async function createOrEditPortForward() {
           v-model="reflectionZones"
           :invalid-message="validationErrorBag.getFirstFor('reflectionZones')"
           :multiple="true"
+          :noResultsLabel="t('ne_combobox.no_results')"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :noOptionsLabel="t('ne_combobox.no_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
       </template>
       <hr />

--- a/src/components/standalone/firewall/CreateOrEditZoneDrawer.vue
+++ b/src/components/standalone/firewall/CreateOrEditZoneDrawer.vue
@@ -4,11 +4,10 @@
 -->
 
 <script lang="ts" setup>
-import type { NeComboboxOption } from '@nethserver/vue-tailwind-lib'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   getAxiosErrorMessage,
   NeButton,
-  NeCombobox,
   NeInlineNotification,
   NeRadioSelection,
   NeTextInput,
@@ -261,6 +260,11 @@ function validate(): boolean {
         :options="zoneComboboxOptions"
         :placeholder="forwardPlaceholder"
         multiple
+        :noResultsLabel="t('ne_combobox.no_results')"
+        :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+        :noOptionsLabel="t('ne_combobox.no_options_label')"
+        :selected-label="t('ne_combobox.selected')"
+        :user-input-label="t('ne_combobox.user_input_label')"
       />
       <NeCombobox
         v-model="forwardsFrom"
@@ -269,6 +273,11 @@ function validate(): boolean {
         :options="zoneComboboxOptions"
         :placeholder="forwardPlaceholder"
         multiple
+        :noResultsLabel="t('ne_combobox.no_results')"
+        :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+        :noOptionsLabel="t('ne_combobox.no_options_label')"
+        :selected-label="t('ne_combobox.selected')"
+        :user-input-label="t('ne_combobox.user_input_label')"
       />
       <NeToggle
         v-model="trafficToWan"

--- a/src/components/standalone/hotspot/SettingsContent.vue
+++ b/src/components/standalone/hotspot/SettingsContent.vue
@@ -5,11 +5,11 @@
 
 <script lang="ts" setup>
 import { onMounted, ref } from 'vue'
+import { NeCombobox } from '@nethesis/vue-components'
 import {
   focusElement,
   getAxiosErrorMessage,
   NeButton,
-  NeCombobox,
   NeInlineNotification,
   NeModal,
   NeSkeleton,
@@ -634,6 +634,11 @@ function goToInterfaces() {
             :label="t('standalone.hotspot.settings.configuration_parent_hotspot')"
             class="grow"
             :disabled="!isLoggedIn || activeConfiguration"
+            :noResultsLabel="t('ne_combobox.no_results')"
+            :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+            :noOptionsLabel="t('ne_combobox.no_options_label')"
+            :selected-label="t('ne_combobox.selected')"
+            :user-input-label="t('ne_combobox.user_input_label')"
           />
           <NeTextInput
             v-model="configurationForm.unitName"
@@ -662,6 +667,11 @@ function goToInterfaces() {
             :disabled="!isLoggedIn"
             class="grow"
             ref="networkDeviceRef"
+            :noResultsLabel="t('ne_combobox.no_results')"
+            :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+            :noOptionsLabel="t('ne_combobox.no_options_label')"
+            :selected-label="t('ne_combobox.selected')"
+            :user-input-label="t('ne_combobox.user_input_label')"
           >
             <template #tooltip>
               <NeTooltip>

--- a/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
+++ b/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
@@ -25,6 +25,7 @@ import {
   validateIp4Cidr
 } from '@/lib/validation'
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   NeFormItemLabel,
   NeSideDrawer,
@@ -33,12 +34,10 @@ import {
   NeInlineNotification,
   NeRadioSelection,
   NeCheckbox,
-  NeCombobox,
   NeCard,
   NeSkeleton,
   focusElement,
-  getAxiosErrorMessage,
-  type NeComboboxOption
+  getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'
 import { cloneDeep, isEmpty, toUpper } from 'lodash-es'
 import { ref, watch, computed, type PropType, type Ref } from 'vue'
@@ -848,6 +847,8 @@ async function listZonesForDeviceConfig() {
             :noOptionsLabel="t('standalone.interfaces_and_devices.no_devices_available')"
             :disabled="loading.configure"
             ref="selectedDevicesForBridgeOrBondRef"
+            :selected-label="t('ne_combobox.selected')"
+            :user-input-label="t('ne_combobox.user_input_label')"
           />
           <!-- bonding policy -->
           <NeCombobox
@@ -860,6 +861,9 @@ async function listZonesForDeviceConfig() {
             :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
             :disabled="loading.configure"
             ref="bondingPolicyRef"
+            :noOptionsLabel="t('ne_combobox.no_options_label')"
+            :selected-label="t('ne_combobox.selected')"
+            :user-input-label="t('ne_combobox.user_input_label')"
           />
           <!-- bond primary device -->
           <NeCombobox
@@ -875,6 +879,9 @@ async function listZonesForDeviceConfig() {
             :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
             :disabled="loading.configure"
             ref="bondPrimaryDeviceRef"
+            :noOptionsLabel="t('ne_combobox.no_options_label')"
+            :selected-label="t('ne_combobox.selected')"
+            :user-input-label="t('ne_combobox.user_input_label')"
           />
         </template>
         <!-- name -->

--- a/src/components/standalone/interfaces_and_devices/CreateVlanDeviceDrawer.vue
+++ b/src/components/standalone/interfaces_and_devices/CreateVlanDeviceDrawer.vue
@@ -8,16 +8,15 @@ import { getName, isBond, isVlan } from '@/lib/standalone/network'
 import { ubusCall } from '@/lib/standalone/ubus'
 import { validateRequired, validateVlanId } from '@/lib/validation'
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   NeSideDrawer,
   NeTextInput,
   NeButton,
   NeInlineNotification,
   NeRadioSelection,
-  NeCombobox,
   focusElement,
-  getAxiosErrorMessage,
-  type NeComboboxOption
+  getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'
 import { cloneDeep } from 'lodash-es'
 import { ref, watch, computed, type Ref } from 'vue'
@@ -258,6 +257,9 @@ function validate() {
           :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
           :disabled="loading.create"
           ref="baseDeviceRef"
+          :noOptionsLabel="t('ne_combobox.no_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeInlineNotification
           v-if="error.notificationTitle"

--- a/src/components/standalone/ipsec_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/ipsec_tunnel/CreateOrEditTunnelDrawer.vue
@@ -17,19 +17,18 @@ import type { IpsecTunnel } from '@/views/standalone/vpn/IPsecTunnelView.vue'
 import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import NeStepper from '../NeStepper.vue'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   NeSideDrawer,
   NeSkeleton,
   NeButton,
   NeToggle,
   NeTextInput,
-  NeCombobox,
   NeTooltip,
   NeRadioSelection,
   NeFormItemLabel,
   NeTitle,
   NeInlineNotification,
-  type NeComboboxOption,
   getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'
 import { ubusCall } from '@/lib/standalone/ubus'
@@ -514,6 +513,9 @@ watch(
           :options="wanOptions"
           :noOptionsLabel="t('ne_combobox.no_options_label')"
           :noResultsLabel="t('ne_combobox.no_results')"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeTextInput
           v-model="remoteIpAddress"
@@ -540,6 +542,7 @@ watch(
           :selected-label="t('ne_combobox.selected')"
           :user-input-label="t('ne_combobox.user_input_label')"
           :accept-user-input="true"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
         />
         <NeMultiTextInput
           v-model="remoteNetworks"
@@ -617,6 +620,9 @@ watch(
           :noOptionsLabel="t('ne_combobox.no_options_label')"
           :noResultsLabel="t('ne_combobox.no_results')"
           :options="ikeVersionOptions"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeCombobox
           v-model="ikeEncryptionAlgorithm"
@@ -625,6 +631,9 @@ watch(
           :noOptionsLabel="t('ne_combobox.no_options_label')"
           :noResultsLabel="t('ne_combobox.no_results')"
           :options="encryptionOptions"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeCombobox
           v-model="ikeIntegrityAlgorithm"
@@ -633,6 +642,9 @@ watch(
           :noOptionsLabel="t('ne_combobox.no_options_label')"
           :noResultsLabel="t('ne_combobox.no_results')"
           :options="integrityOptions"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeCombobox
           v-model="ikeDiffieHellmanGroup"
@@ -641,6 +653,9 @@ watch(
           :noOptionsLabel="t('ne_combobox.no_options_label')"
           :noResultsLabel="t('ne_combobox.no_results')"
           :options="diffieHellmanOptions.filter((x) => x.id != '')"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeTextInput
           v-model="ikeKeyLifetime"
@@ -656,6 +671,9 @@ watch(
           :noOptionsLabel="t('ne_combobox.no_options_label')"
           :noResultsLabel="t('ne_combobox.no_results')"
           :options="encryptionOptions"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeCombobox
           v-model="espIntegrityAlgorithm"
@@ -664,6 +682,9 @@ watch(
           :noOptionsLabel="t('ne_combobox.no_options_label')"
           :noResultsLabel="t('ne_combobox.no_results')"
           :options="integrityOptions"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeCombobox
           v-model="espDiffieHellmanGroup"
@@ -672,6 +693,9 @@ watch(
           :noOptionsLabel="t('ne_combobox.no_options_label')"
           :noResultsLabel="t('ne_combobox.no_results')"
           :options="diffieHellmanOptions"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeTextInput
           v-model="espKeyLifetime"

--- a/src/components/standalone/multi-wan/MultiWanGeneralSettings.vue
+++ b/src/components/standalone/multi-wan/MultiWanGeneralSettings.vue
@@ -7,11 +7,10 @@
 import { onMounted, ref } from 'vue'
 import FormLayout from '@/components/standalone/FormLayout.vue'
 import { useI18n } from 'vue-i18n'
-import type { NeComboboxOption } from '@nethserver/vue-tailwind-lib'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   getAxiosErrorMessage,
   NeButton,
-  NeCombobox,
   NeFormItemLabel,
   NeInlineNotification,
   NeSkeleton,
@@ -229,18 +228,33 @@ onMounted(() => {
           :invalid-message="messageBag.get('ping.timeout')?.[0]"
           :label="t('standalone.multi_wan.ping_timeout')"
           :options="timeoutOptions([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])"
+          :noResultsLabel="t('ne_combobox.no_results')"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :noOptionsLabel="t('ne_combobox.no_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeCombobox
           v-model.number="data.ping_interval"
           :disabled="sending"
           :label="t('standalone.multi_wan.ping_interval')"
           :options="timeoutOptions([1, 3, 5, 10, 20, 30, 60, 300, 600, 900, 1800, 3600])"
+          :noResultsLabel="t('ne_combobox.no_results')"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :noOptionsLabel="t('ne_combobox.no_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeCombobox
           v-model.number="data.ping_failure_interval"
           :disabled="sending"
           :label="t('standalone.multi_wan.ping_failure_interval')"
           :options="timeoutOptions([1, 3, 5, 10, 20, 30, 60, 300, 600, 900, 1800, 3600])"
+          :noResultsLabel="t('ne_combobox.no_results')"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :noOptionsLabel="t('ne_combobox.no_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
       </div>
     </FormLayout>
@@ -255,12 +269,22 @@ onMounted(() => {
           :disabled="sending"
           :label="t('standalone.multi_wan.interface_down')"
           :options="pingsOptions([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])"
+          :noResultsLabel="t('ne_combobox.no_results')"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :noOptionsLabel="t('ne_combobox.no_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeCombobox
           v-model="data.interface_up_threshold"
           :disabled="sending"
           :label="t('standalone.multi_wan.interface_up')"
           :options="pingsOptions([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])"
+          :noResultsLabel="t('ne_combobox.no_results')"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :noOptionsLabel="t('ne_combobox.no_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
       </div>
     </FormLayout>

--- a/src/components/standalone/multi-wan/MultiWanManager.vue
+++ b/src/components/standalone/multi-wan/MultiWanManager.vue
@@ -6,15 +6,22 @@
 <script lang="ts" setup>
 import { useI18n } from 'vue-i18n'
 import { onMounted, onUnmounted, ref } from 'vue'
+import { NeBadge } from '@nethesis/vue-components'
 import {
   getAxiosErrorMessage,
-  NeBadge,
   NeButton,
   NeDropdown,
   NeInlineNotification
 } from '@nethserver/vue-tailwind-lib'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { faCirclePlus } from '@fortawesome/free-solid-svg-icons'
+import {
+  faCirclePlus,
+  faCircleCheck,
+  faCircleXmark,
+  faWarning,
+  faCircleStop,
+  faClock
+} from '@fortawesome/free-solid-svg-icons'
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
 import type { Member, Policy, Rule } from '@/composables/useMwan'
 import { useMwan } from '@/composables/useMwan'
@@ -92,16 +99,16 @@ function reloadConfig() {
 function badgeIcon(member: Member) {
   switch (member.status) {
     case 'online':
-      return ['fas', 'circle-check']
+      return faCircleCheck
     case 'offline':
-      return ['fas', 'circle-xmark']
+      return faCircleXmark
     case 'disconnecting':
     case 'connecting':
-      return ['fas', 'warning']
+      return faWarning
     case 'disabled':
-      return ['fas', 'circle-stop']
+      return faCircleStop
     default:
-      return ['fas', 'clock']
+      return faClock
   }
 }
 

--- a/src/components/standalone/multi-wan/PolicyCreator.vue
+++ b/src/components/standalone/multi-wan/PolicyCreator.vue
@@ -4,10 +4,9 @@
 -->
 
 <script lang="ts" setup>
-import type { NeComboboxOption } from '@nethserver/vue-tailwind-lib'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   NeButton,
-  NeCombobox,
   NeFormItemLabel,
   NeInlineNotification,
   NeRadioSelection,
@@ -178,6 +177,11 @@ function create() {
                 :options="availableGateways"
                 :placeholder="t('standalone.multi_wan.choose_gateway')"
                 class="grow"
+                :noResultsLabel="t('ne_combobox.no_results')"
+                :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+                :noOptionsLabel="t('ne_combobox.no_options_label')"
+                :selected-label="t('ne_combobox.selected')"
+                :user-input-label="t('ne_combobox.user_input_label')"
               />
               <NeTextInput
                 v-if="policyForm.selection != 'backup'"

--- a/src/components/standalone/multi-wan/PolicyEditor.vue
+++ b/src/components/standalone/multi-wan/PolicyEditor.vue
@@ -7,10 +7,9 @@
 import type { PropType } from 'vue'
 import { computed, onMounted, reactive, ref, toRef } from 'vue'
 import type { Policy } from '@/composables/useMwan'
-import type { NeComboboxOption } from '@nethserver/vue-tailwind-lib'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   NeButton,
-  NeCombobox,
   NeFormItemLabel,
   NeInlineNotification,
   NeRadioSelection,
@@ -131,6 +130,11 @@ function submit() {
                 :options="availableGateways"
                 :placeholder="t('standalone.multi_wan.choose_gateway')"
                 class="grow"
+                :noResultsLabel="t('ne_combobox.no_results')"
+                :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+                :noOptionsLabel="t('ne_combobox.no_options_label')"
+                :selected-label="t('ne_combobox.selected')"
+                :user-input-label="t('ne_combobox.user_input_label')"
               />
               <NeTextInput
                 v-if="policyForm.selection != 'backup'"

--- a/src/components/standalone/multi-wan/RuleCreator.vue
+++ b/src/components/standalone/multi-wan/RuleCreator.vue
@@ -4,7 +4,8 @@
 -->
 
 <script lang="ts" setup>
-import { NeButton, NeCombobox, NeSideDrawer, NeTextInput } from '@nethserver/vue-tailwind-lib'
+import { NeCombobox } from '@nethesis/vue-components'
+import { NeButton, NeSideDrawer, NeTextInput } from '@nethserver/vue-tailwind-lib'
 import { ref, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { Policy } from '@/composables/useMwan'
@@ -89,6 +90,11 @@ function save() {
         :options="policyDropdownOptions"
         :placeholder="policyDropdownPlaceholder"
         name="policy"
+        :noResultsLabel="t('ne_combobox.no_results')"
+        :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+        :noOptionsLabel="t('ne_combobox.no_options_label')"
+        :selected-label="t('ne_combobox.selected')"
+        :user-input-label="t('ne_combobox.user_input_label')"
       />
       <NeCombobox
         v-model="protocol"
@@ -98,6 +104,11 @@ function save() {
         :options="protocolOptions"
         :placeholder="protocolOptions[0].label"
         name="protocol"
+        :noResultsLabel="t('ne_combobox.no_results')"
+        :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+        :noOptionsLabel="t('ne_combobox.no_options_label')"
+        :selected-label="t('ne_combobox.selected')"
+        :user-input-label="t('ne_combobox.user_input_label')"
       />
       <NeTextInput
         v-model="sourceAddress"

--- a/src/components/standalone/multi-wan/RuleEditor.vue
+++ b/src/components/standalone/multi-wan/RuleEditor.vue
@@ -6,7 +6,8 @@
 <script lang="ts" setup>
 import { useI18n } from 'vue-i18n'
 import { ref, toRef } from 'vue'
-import { NeButton, NeCombobox, NeSideDrawer, NeTextInput } from '@nethserver/vue-tailwind-lib'
+import { NeCombobox } from '@nethesis/vue-components'
+import { NeButton, NeSideDrawer, NeTextInput } from '@nethserver/vue-tailwind-lib'
 import { MessageBag } from '@/lib/validation'
 import type { Policy, Rule } from '@/composables/useMwan'
 import { ubusCall, ValidationError } from '@/lib/standalone/ubus'
@@ -92,6 +93,11 @@ function save() {
         :options="policyDropdownOptions"
         :placeholder="policyDropdownPlaceholder"
         name="policy"
+        :noResultsLabel="t('ne_combobox.no_results')"
+        :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+        :noOptionsLabel="t('ne_combobox.no_options_label')"
+        :selected-label="t('ne_combobox.selected')"
+        :user-input-label="t('ne_combobox.user_input_label')"
       />
       <NeCombobox
         v-model="protocol"
@@ -101,6 +107,11 @@ function save() {
         :options="protocolOptions"
         :placeholder="protocolOptions[0].label"
         name="protocol"
+        :noResultsLabel="t('ne_combobox.no_results')"
+        :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+        :noOptionsLabel="t('ne_combobox.no_options_label')"
+        :selected-label="t('ne_combobox.selected')"
+        :user-input-label="t('ne_combobox.user_input_label')"
       />
       <NeTextInput
         v-model="sourceAddress"

--- a/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
@@ -16,6 +16,7 @@ import {
   validateUciName,
   type validationOutput
 } from '@/lib/validation'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   NeSideDrawer,
   NeInlineNotification,
@@ -24,11 +25,9 @@ import {
   NeButton,
   getAxiosErrorMessage,
   NeTooltip,
-  NeCombobox,
   NeFormItemLabel,
   NeTextArea,
   NeSkeleton,
-  type NeComboboxOption,
   NeRadioSelection
 } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
@@ -680,6 +679,7 @@ watch(
           :selected-label="t('ne_combobox.selected')"
           :user-input-label="t('ne_combobox.user_input_label')"
           :accept-user-input="true"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
           ><template #tooltip>
             <NeTooltip
               ><template #content>{{
@@ -841,6 +841,9 @@ watch(
           :no-options-label="t('ne_combobox.no_options_label')"
           :no-results-label="t('ne_combobox.no_results')"
           v-model="compression"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeCombobox
           :label="t('standalone.openvpn_tunnel.digest')"
@@ -848,6 +851,9 @@ watch(
           :no-options-label="t('ne_combobox.no_options_label')"
           :no-results-label="t('ne_combobox.no_results')"
           v-model="digest"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeCombobox
           :label="t('standalone.openvpn_tunnel.cipher')"
@@ -855,6 +861,9 @@ watch(
           :no-options-label="t('ne_combobox.no_options_label')"
           :no-results-label="t('ne_combobox.no_results')"
           v-model="cipher"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
         <NeCombobox
           :label="t('standalone.openvpn_tunnel.enforce_minimum_tls_version')"
@@ -863,6 +872,9 @@ watch(
           :options="tlsOptions"
           v-model="minimumTLSVersion"
           v-if="!isClientTunnel"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
       </template>
       <hr />

--- a/src/components/standalone/reverse_proxy/CreateOrEditProxyDrawer.vue
+++ b/src/components/standalone/reverse_proxy/CreateOrEditProxyDrawer.vue
@@ -16,16 +16,15 @@ import {
 import type { ReverseProxy } from '@/views/standalone/network/ReverseProxyView.vue'
 import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   NeSideDrawer,
   NeSkeleton,
   NeInlineNotification,
   NeTextInput,
-  NeCombobox,
   NeButton,
   NeRadioSelection,
   NeTooltip,
-  type NeComboboxOption,
   getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'
 import NeMultiTextInput from '../NeMultiTextInput.vue'
@@ -316,6 +315,9 @@ watch(
           :noOptionsLabel="t('ne_combobox.no_options_label')"
           :noResultsLabel="t('ne_combobox.no_results')"
           :options="certificateOptions"
+          :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+          :selected-label="t('ne_combobox.selected')"
+          :user-input-label="t('ne_combobox.user_input_label')"
         />
       </template>
       <NeTextInput

--- a/src/components/standalone/routes/CreateOrEditRouteDrawer.vue
+++ b/src/components/standalone/routes/CreateOrEditRouteDrawer.vue
@@ -4,11 +4,11 @@
 -->
 
 <script lang="ts" setup>
+import { NeCombobox } from '@nethesis/vue-components'
 import {
   getAxiosErrorMessage,
   focusElement,
   NeButton,
-  NeCombobox,
   NeInlineNotification,
   NeSideDrawer,
   NeSkeleton,
@@ -530,6 +530,11 @@ function submit() {
         :label="t('standalone.routes.route_interface')"
         :placeholder="t('standalone.routes.route_choose_interface')"
         class="grow"
+        :noResultsLabel="t('ne_combobox.no_results')"
+        :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+        :noOptionsLabel="t('ne_combobox.no_options_label')"
+        :selected-label="t('ne_combobox.selected')"
+        :user-input-label="t('ne_combobox.user_input_label')"
       />
       <NeButton
         kind="tertiary"
@@ -554,6 +559,11 @@ function submit() {
             :label="t('standalone.routes.route_type')"
             :placeholder="t('standalone.routes.route_choose_type')"
             class="grow"
+            :noResultsLabel="t('ne_combobox.no_results')"
+            :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+            :noOptionsLabel="t('ne_combobox.no_options_label')"
+            :selected-label="t('ne_combobox.selected')"
+            :user-input-label="t('ne_combobox.user_input_label')"
           />
           <NeTextInput
             v-model="form.mtu"

--- a/src/components/standalone/security/FlashstartContent.vue
+++ b/src/components/standalone/security/FlashstartContent.vue
@@ -7,17 +7,16 @@
 import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import FormLayout from '@/components/standalone/FormLayout.vue'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   NeSkeleton,
   NeTextInput,
   NeToggle,
   NeTooltip,
-  NeCombobox,
   NeButton,
   NeInlineNotification,
   focusElement,
   getAxiosErrorMessage,
-  type NeComboboxOption,
   NeFormItemLabel
 } from '@nethserver/vue-tailwind-lib'
 import NeMultiTextInput from '@/components/standalone/NeMultiTextInput.vue'
@@ -301,6 +300,11 @@ function save() {
             :options="zones"
             :invalid-message="error.zones"
             ref="zonesRef"
+            :noResultsLabel="t('ne_combobox.no_results')"
+            :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+            :noOptionsLabel="t('ne_combobox.no_options_label')"
+            :selected-label="t('ne_combobox.selected')"
+            :user-input-label="t('ne_combobox.user_input_label')"
           />
           <NeMultiTextInput
             v-model="form.bypassSource"

--- a/src/components/standalone/subscription/UnitSubscription.vue
+++ b/src/components/standalone/subscription/UnitSubscription.vue
@@ -6,6 +6,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import FormLayout from '@/components/standalone/FormLayout.vue'
+import { NeBadge } from '@nethesis/vue-components'
 import {
   NeButton,
   NeTextInput,
@@ -13,8 +14,7 @@ import {
   NeInlineNotification,
   NeSkeleton,
   focusElement,
-  getAxiosErrorMessage,
-  NeBadge
+  getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'
 import type { SubscriptionDataType } from '@/views/standalone/system/SubscriptionView.vue'
 import type { PropType } from 'vue'

--- a/src/components/standalone/system_settings/GeneralSettings.vue
+++ b/src/components/standalone/system_settings/GeneralSettings.vue
@@ -7,13 +7,13 @@
 import { getUciConfig, ubusCall } from '@/lib/standalone/ubus'
 import { validateHostname, validateRequired } from '@/lib/validation'
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
+import { NeCombobox } from '@nethesis/vue-components'
 import {
   NeButton,
   NeTextInput,
   NeTextArea,
   NeFormItemLabel,
   NeSkeleton,
-  NeCombobox,
   NeInlineNotification,
   getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'
@@ -281,6 +281,9 @@ async function syncWithNtpServer() {
             :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
             :disabled="loading.save"
             ref="timezoneRef"
+            :noOptionsLabel="t('ne_combobox.no_options_label')"
+            :selected-label="t('ne_combobox.selected')"
+            :user-input-label="t('ne_combobox.user_input_label')"
           />
           <!-- local time -->
           <div>

--- a/src/components/standalone/system_settings/TimeSynchronization.vue
+++ b/src/components/standalone/system_settings/TimeSynchronization.vue
@@ -7,16 +7,15 @@
 import { getUciConfig, ubusCall } from '@/lib/standalone/ubus'
 import { validateHost, validateRequired } from '@/lib/validation'
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   NeButton,
   NeCheckbox,
   NeToggle,
   NeSkeleton,
-  NeCombobox,
   NeInlineNotification,
   getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'
-import type { NeComboboxOption } from '@nethserver/vue-tailwind-lib'
 import { isEmpty, uniq } from 'lodash-es'
 import { computed, onMounted, ref, type Ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -297,6 +296,9 @@ function resetNtpServerErrors() {
                     :noResultsLabel="t('ne_combobox.no_results')"
                     :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
                     :disabled="loading.save"
+                    :noOptionsLabel="t('ne_combobox.no_options_label')"
+                    :selected-label="t('ne_combobox.selected')"
+                    :user-input-label="t('ne_combobox.user_input_label')"
                   />
                 </div>
               </Transition>

--- a/src/composables/useRuleForm.ts
+++ b/src/composables/useRuleForm.ts
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: GPL-3.0-or-later
 
 import { useI18n } from 'vue-i18n'
-import type { NeComboboxOption } from '@nethserver/vue-tailwind-lib'
+import { type NeComboboxOption } from '@nethesis/vue-components'
 import type { Ref } from 'vue'
 import { computed, ref, watch } from 'vue'
 import type { Policy, Rule } from '@/composables/useMwan'

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,7 +1,7 @@
 //  Copyright (C) 2023 Nethesis S.r.l.
 //  SPDX-License-Identifier: GPL-3.0-or-later
 
-import type { NeComboboxOption } from '@nethserver/vue-tailwind-lib'
+import { type NeComboboxOption } from '@nethesis/vue-components'
 
 export interface validationOutput {
   valid: Boolean

--- a/src/views/standalone/LogsView.vue
+++ b/src/views/standalone/LogsView.vue
@@ -1,8 +1,7 @@
 <script lang="ts" setup>
-import type { NeComboboxOption } from '@nethserver/vue-tailwind-lib'
+import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
 import {
   getAxiosErrorMessage,
-  NeCombobox,
   NeInlineNotification,
   NeTextInput,
   NeTitle,
@@ -156,6 +155,11 @@ function fetchData() {
         :invalid-message="errorBag.getFirstFor('limits')"
         :label="t('standalone.logs.limit_rows')"
         :options="logLimitComboboxOption"
+        :noResultsLabel="t('ne_combobox.no_results')"
+        :limitedOptionsLabel="t('ne_combobox.limited_options_label')"
+        :noOptionsLabel="t('ne_combobox.no_options_label')"
+        :selected-label="t('ne_combobox.selected')"
+        :user-input-label="t('ne_combobox.user_input_label')"
       />
       <div class="col-span-1 flex gap-8 sm:col-span-2">
         <NeToggle v-model="wrapRow" :label="t('standalone.logs.wrap_row')" />

--- a/src/views/standalone/firewall/ZonesAndPolicies.vue
+++ b/src/views/standalone/firewall/ZonesAndPolicies.vue
@@ -4,13 +4,8 @@
 -->
 
 <script lang="ts" setup>
-import {
-  NeBadge,
-  NeButton,
-  NeDropdown,
-  NeInlineNotification,
-  NeTitle
-} from '@nethserver/vue-tailwind-lib'
+import { NeBadge } from '@nethesis/vue-components'
+import { NeButton, NeDropdown, NeInlineNotification, NeTitle } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
 import NeTable from '@/components/standalone/NeTable.vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'

--- a/src/views/standalone/network/InterfacesAndDevicesView.vue
+++ b/src/views/standalone/network/InterfacesAndDevicesView.vue
@@ -5,11 +5,11 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { NeBadge } from '@nethesis/vue-components'
 import {
   NeTitle,
   NeButton,
   NeDropdown,
-  NeBadge,
   NeInlineNotification,
   getAxiosErrorMessage,
   byteFormat1000


### PR DESCRIPTION
- Import NeCombobox and NeBadge components from `vue-components` instead of `vue-tailwind-lib`
- Pass i18n props to NeCombobox. Before this change, English strings where used as a fallback whenever i18n props were not passed to the component.