### PR TITLE
OpenVPN tunnel: fix notification showing even if no error is encountered

### DIFF
--- a/src/components/standalone/openvpn_tunnel/DeleteTunnelModal.vue
+++ b/src/components/standalone/openvpn_tunnel/DeleteTunnelModal.vue
@@ -68,7 +68,7 @@ function close() {
       })
     }}
     <NeInlineNotification
-      v-if="error"
+      v-if="error.notificationDescription"
       kind="error"
       :title="t('error.cannot_delete_tunnel')"
       :description="error.notificationDescription"

--- a/src/components/standalone/openvpn_tunnel/DownloadTunnelModal.vue
+++ b/src/components/standalone/openvpn_tunnel/DownloadTunnelModal.vue
@@ -114,7 +114,7 @@ function close() {
       </template>
     </NeRadioSelection>
     <NeInlineNotification
-      v-if="error"
+      v-if="error.notificationDescription"
       kind="error"
       :title="t('error.cannot_download_tunnel')"
       :description="error.notificationDescription"

--- a/src/components/standalone/openvpn_tunnel/ImportConfigurationDrawer.vue
+++ b/src/components/standalone/openvpn_tunnel/ImportConfigurationDrawer.vue
@@ -81,7 +81,7 @@ async function importConfiguration() {
     <div class="flex flex-col gap-y-6">
       <NeInlineNotification
         kind="error"
-        v-if="importConfigurationError"
+        v-if="importConfigurationError.notificationDescription"
         :title="t('error.cannot_import_configuration')"
         :description="importConfigurationError.notificationDescription"
         ><template v-if="importConfigurationError.notificationDetails" #details>


### PR DESCRIPTION
- Fix issue where the error notification would display even if no error is encountered in the download tunnel modal, delete tunnel modal and import configuration drawer

Cards:
- https://trello.com/c/aDkk2gr3/261-openvpn-tunnel-error-when-importing-client-config
- https://trello.com/c/0qn3rwEO/260-openvpn-tunnel-error-when-downloading-client-config