### PR TITLE
QoS: exclude already configured interfaces from create/edit drawer

### DIFF
--- a/src/components/standalone/qos/CreateOrEditQoSInterfaceDrawer.vue
+++ b/src/components/standalone/qos/CreateOrEditQoSInterfaceDrawer.vue
@@ -31,6 +31,7 @@ import type { QoSInterface } from '@/views/standalone/network/QoSView.vue'
 const props = defineProps<{
   isShown: boolean
   itemToEdit?: QoSInterface
+  configuredInterfaces: string[]
 }>()
 
 const { t } = useI18n()
@@ -58,7 +59,12 @@ async function fetchOptions() {
   try {
     loading.value = true
     ifaceOptions.value = (await ubusCall('ns.devices', 'list-devices')).data.all_devices
-      .filter((x: any) => x.iface && x.iface['.type'] === 'interface')
+      .filter(
+        (x: any) =>
+          x.iface &&
+          x.iface['.type'] === 'interface' &&
+          !props.configuredInterfaces.includes(x.iface['.name'])
+      )
       .map((x: any) => ({
         id: x.iface['.name'],
         label: x.iface['.name'],

--- a/src/views/standalone/network/QoSView.vue
+++ b/src/views/standalone/network/QoSView.vue
@@ -175,6 +175,7 @@ onMounted(() => {
   <CreateOrEditQoSInterfaceDrawer
     :is-shown="showCreateOrEditInterfaceDrawer"
     :item-to-edit="selectedInterface"
+    :configured-interfaces="qosInterfaces.map((x) => x.interface)"
     @close="showCreateOrEditInterfaceDrawer = false"
     @add-edit-qos-interface="refreshInterfaces"
   />


### PR DESCRIPTION
- Exclude already configured interfaces from list in create/edit drawer

Card: https://trello.com/c/OnJqKKbI/269-qos-drawer-shows-already-configured-interfaces