### PR TITLE
refactor: bond management processes

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -700,7 +700,7 @@
       "pppoe_password": "Password",
       "remove_configuration_explanation": "Remove '{iface}' configuration? Device '{device}' will become unassigned",
       "delete_bridge_explanation": "Delete bridge '{iface}' and its device '{device}'?",
-      "delete_bond_explanation": "Delete bond '{iface}'?",
+      "delete_bond_explanation": "Remove configuration for bond '{iface}'?",
       "dhcp_hostname_to_send_label": "Hostname to send when requesting DHCP",
       "dhcp_hostname_device": "Send the hostname of this device",
       "dhcp_hostname_do_not_send": "Do not send a hostname",
@@ -748,11 +748,16 @@
       "cannot_remove_device_configuration": "Cannot remove device configuration",
       "hotspot_network": "Network",
       "add_ip_address": "Add IP address",
-      "delete_bond_title": "Delete bond \"{name}\"?",
-      "delete_bond_description": "Delete bond \"{name}\"? The devices bonded will be detached and made available for other configurations.",
+      "delete_bond_title": "Delete bond '{name}'?",
+      "delete_bond_description": "Delete bond '{name}'? The devices bonded will be detached and available for other configurations.",
       "cannot_delete_bond": "Cannot delete bond.",
       "delete_bond": "Delete bond",
-      "edit_bond": "Edit bond"
+      "bond_name": "Bond name",
+      "management_ipv4_address_cidr": "Management IPv4 address (CIDR notation)",
+      "management_ipv4_address_cidr_tooltip": "Lorem ipsum dolor sit amet, consectetur adipisci elit, sed do eiusmod tempor incidunt ut labore et dolore magna aliqua.",
+      "create_bond": "Create bond",
+      "configure_bond": "Configure bond",
+      "configure_bond_name": "Configure bond {name}"
     },
     "multi_wan": {
       "title": "MultiWAN",

--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -747,7 +747,12 @@
       "custom_zone": "Custom",
       "cannot_remove_device_configuration": "Cannot remove device configuration",
       "hotspot_network": "Network",
-      "add_ip_address": "Add IP address"
+      "add_ip_address": "Add IP address",
+      "delete_bond_title": "Delete bond \"{name}\"?",
+      "delete_bond_description": "Delete bond \"{name}\"? The devices bonded will be detached and made available for other configurations.",
+      "cannot_delete_bond": "Cannot delete bond.",
+      "delete_bond": "Delete bond",
+      "edit_bond": "Edit bond"
     },
     "multi_wan": {
       "title": "MultiWAN",

--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -754,7 +754,7 @@
       "delete_bond": "Delete bond",
       "bond_name": "Bond name",
       "management_ipv4_address_cidr": "Management IPv4 address (CIDR notation)",
-      "management_ipv4_address_cidr_tooltip": "Lorem ipsum dolor sit amet, consectetur adipisci elit, sed do eiusmod tempor incidunt ut labore et dolore magna aliqua.",
+      "management_ipv4_address_cidr_tooltip": "This IP address is for internal use only and won't be the primary address of the bond. Make sure it's not already used in your network",
       "create_bond": "Create bond",
       "configure_bond": "Configure bond",
       "configure_bond_name": "Configure bond {name}"

--- a/src/components/standalone/account/two_fa/RevokeTwoFaModal.vue
+++ b/src/components/standalone/account/two_fa/RevokeTwoFaModal.vue
@@ -148,7 +148,7 @@ async function revoke() {
     :cancelLabel="t('common.cancel')"
     primaryButtonKind="danger"
     :primaryButtonLoading="loading.verifyOtp || loading.revokeTwoFa"
-    :closeAriaLabe="t('common.close')"
+    :closeAriaLabel="t('common.close')"
     @close="emit('close')"
     @primaryClick="verifyOtp"
   >

--- a/src/components/standalone/dpi/DeleteDpiRuleModal.vue
+++ b/src/components/standalone/dpi/DeleteDpiRuleModal.vue
@@ -79,7 +79,7 @@ async function deleteRule() {
     primaryButtonKind="danger"
     :primaryButtonDisabled="loading.deleteRule"
     :primaryButtonLoading="loading.deleteRule"
-    :closeAriaLabe="t('common.close')"
+    :closeAriaLabel="t('common.close')"
     @close="emit('close')"
     @primaryClick="deleteRule"
   >

--- a/src/components/standalone/firewall/rules/DeleteFirewallRuleModal.vue
+++ b/src/components/standalone/firewall/rules/DeleteFirewallRuleModal.vue
@@ -77,7 +77,7 @@ async function deleteRule() {
     primaryButtonKind="danger"
     :primaryButtonDisabled="loading.deleteRule"
     :primaryButtonLoading="loading.deleteRule"
-    :closeAriaLabe="t('common.close')"
+    :closeAriaLabel="t('common.close')"
     @close="emit('close')"
     @primaryClick="deleteRule"
   >

--- a/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
+++ b/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
@@ -325,6 +325,20 @@ const drawerTitle = computed(() => {
 })
 
 watch(
+  logicalIfaceType,
+  () => {
+    if (logicalIfaceType.value == 'bond') {
+      const firstRandom = Math.floor(Math.random() * 255)
+      const secondRandom = Math.floor(Math.random() * 255)
+      ipv4Address.value = `127.${firstRandom}.${secondRandom}.1/30`
+    } else {
+      ipv4Address.value = ''
+    }
+  },
+  { immediate: true }
+)
+
+watch(
   () => props.isShown,
   () => {
     if (props.isShown) {

--- a/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
+++ b/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
@@ -479,6 +479,7 @@ function prepareConfigureDeviceData() {
   if (props.deviceType === 'logical' && logicalIfaceType.value === 'bond') {
     data.bonding_policy = bondingPolicy.value
     data.bond_primary_device = bondPrimaryDevice.value
+    delete data.zone
   }
 
   if (protocol.value === 'pppoe') {
@@ -586,7 +587,11 @@ function validate() {
     } else {
       // check syntax
       {
-        let { valid, errMessage, i18Params } = validateUciName(interfaceName.value, 15)
+        let maxLen = 15
+        if (logicalIfaceType.value == 'bond') {
+          maxLen = 10
+        }
+        let { valid, errMessage, i18Params } = validateUciName(interfaceName.value, maxLen)
         if (!valid) {
           error.value.interfaceName = t(errMessage as string, i18Params as any)
           if (isValidationOk) {
@@ -904,7 +909,7 @@ async function listZonesForDeviceConfig() {
         </div>
         <!-- zone -->
         <NeRadioSelection
-          v-else
+          v-else-if="logicalIfaceType != 'bond'"
           v-model="zone"
           card
           :label="t('standalone.interfaces_and_devices.zone')"

--- a/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
+++ b/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
@@ -10,7 +10,9 @@ import {
   getZoneColor,
   getZoneIcon,
   isBond,
-  isBridge
+  isBridge,
+  isConfiguredBond,
+  isUnconfiguredBond
 } from '@/lib/standalone/network'
 import { ubusCall } from '@/lib/standalone/ubus'
 import {
@@ -218,9 +220,7 @@ const zoneOptions = computed(() => {
       id: zone.name,
       label: toUpper(zone.name),
       description: getZoneColor(zone.name),
-      icon: getZoneIcon(zone.name),
-      disabled:
-        zone.name === 'wan' && props.deviceType === 'logical' && logicalIfaceType.value === 'bond' // disable red zone when configuring bond
+      icon: getZoneIcon(zone.name)
     }
   })
 })
@@ -236,6 +236,11 @@ const protocolOptions = computed(() => {
 // returns true when configuring an unassigned device, false when editing an already configured interface
 const isConfiguringFromScratch = computed(() => {
   return !props.interfaceToEdit
+})
+
+// returns true only when creating a new bond (not when configuring it)
+const isCreatingBond = computed(() => {
+  return props.deviceType === 'logical' && logicalIfaceType.value === 'bond'
 })
 
 const bridgeOrBondDevicesOptions: Ref<NeComboboxOption[]> = computed(() => {
@@ -288,6 +293,37 @@ const devicesUsedByOhterBridgesOrBonds = computed(() => {
   return usedDevices
 })
 
+const primaryButtonLabel = computed(() => {
+  if (isConfiguringFromScratch.value) {
+    if (logicalIfaceType.value === 'bond') {
+      return t('standalone.interfaces_and_devices.create_bond')
+    } else if (props.device.proto === 'bonding') {
+      return t('standalone.interfaces_and_devices.configure_bond')
+    } else {
+      return t('standalone.interfaces_and_devices.configure_interface')
+    }
+  } else {
+    return t('standalone.interfaces_and_devices.reconfigure_interface')
+  }
+})
+
+const drawerTitle = computed(() => {
+  if (props.deviceType === 'physical') {
+    if (props.device.proto === 'bonding') {
+      const bondName = props.device.name.split('bond-')[1]
+      return t('standalone.interfaces_and_devices.configure_bond_name', {
+        name: bondName
+      })
+    } else {
+      return t('standalone.interfaces_and_devices.configure_interface_for_name', {
+        name: props.device.name
+      })
+    }
+  } else {
+    return t('standalone.interfaces_and_devices.create_logical_interface')
+  }
+})
+
 watch(
   () => props.isShown,
   () => {
@@ -329,10 +365,23 @@ watch(
         }
       } else {
         // editing configuration
-        interfaceName.value = props.interfaceToEdit['.name']
+
+        if (isUnconfiguredBond(props.interfaceToEdit)) {
+          interfaceName.value = ''
+          focusElement(interfaceNameRef)
+        } else {
+          interfaceName.value = props.interfaceToEdit['.name']
+        }
+
         // (zone is set inside listZonesForDeviceConfig function)
-        protocol.value = props.interfaceToEdit.proto
-        ipv4Address.value = props.interfaceToEdit.ipaddr || ''
+
+        if (isUnconfiguredBond(props.interfaceToEdit)) {
+          protocol.value = 'static'
+          ipv4Address.value = ''
+        } else {
+          protocol.value = props.interfaceToEdit.proto
+          ipv4Address.value = props.interfaceToEdit.ipaddr || ''
+        }
         ipv4Gateway.value = props.interfaceToEdit.gateway || ''
 
         if (
@@ -812,11 +861,7 @@ async function listZonesForDeviceConfig() {
 <template>
   <NeSideDrawer
     :isShown="isShown"
-    :title="
-      deviceType === 'physical'
-        ? t('standalone.interfaces_and_devices.configure_interface_for_name', { name: device.name })
-        : t('standalone.interfaces_and_devices.create_logical_interface')
-    "
+    :title="drawerTitle"
     :closeAriaLabel="t('standalone.shell.close_side_drawer')"
     @close="closeDrawer"
   >
@@ -890,7 +935,11 @@ async function listZonesForDeviceConfig() {
         </template>
         <!-- name -->
         <NeTextInput
-          :label="t('standalone.interfaces_and_devices.interface_name')"
+          :label="
+            isCreatingBond
+              ? t('standalone.interfaces_and_devices.bond_name')
+              : t('standalone.interfaces_and_devices.interface_name')
+          "
           v-model.trim="interfaceName"
           :invalidMessage="t(error.interfaceName)"
           :disabled="!isConfiguringFromScratch || loading.configure"
@@ -907,9 +956,9 @@ async function listZonesForDeviceConfig() {
             </NeCard>
           </div>
         </div>
-        <!-- zone -->
+        <!-- zone, always show except when creating bond -->
         <NeRadioSelection
-          v-else-if="logicalIfaceType != 'bond'"
+          v-else-if="!isCreatingBond"
           v-model="zone"
           card
           :label="t('standalone.interfaces_and_devices.zone')"
@@ -927,12 +976,24 @@ async function listZonesForDeviceConfig() {
         <div v-show="['static', 'bonding'].includes(protocol)" class="space-y-6">
           <!-- ipv4 address -->
           <NeTextInput
-            :label="t('standalone.interfaces_and_devices.ipv4_address_cidr')"
+            :label="
+              logicalIfaceType === 'bond'
+                ? t('standalone.interfaces_and_devices.management_ipv4_address_cidr')
+                : t('standalone.interfaces_and_devices.ipv4_address_cidr')
+            "
             v-model.trim="ipv4Address"
             :invalidMessage="t(error.ipv4Address)"
             :disabled="loading.configure"
             ref="ipv4AddressRef"
-          />
+          >
+            <template v-if="logicalIfaceType === 'bond'" #tooltip>
+              <NeTooltip>
+                <template #content>
+                  {{ t('standalone.interfaces_and_devices.management_ipv4_address_cidr_tooltip') }}
+                </template>
+              </NeTooltip>
+            </template>
+          </NeTextInput>
           <!-- gateway -->
           <NeTextInput
             v-if="zone === 'wan'"
@@ -1124,11 +1185,7 @@ async function listZonesForDeviceConfig() {
           :disabled="loading.configure"
           :loading="loading.configure"
         >
-          {{
-            isConfiguringFromScratch
-              ? t('standalone.interfaces_and_devices.configure_interface')
-              : t('standalone.interfaces_and_devices.reconfigure_interface')
-          }}
+          {{ primaryButtonLabel }}
         </NeButton>
       </div>
     </form>

--- a/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
+++ b/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
@@ -328,9 +328,11 @@ watch(
   logicalIfaceType,
   () => {
     if (logicalIfaceType.value == 'bond') {
-      const firstRandom = Math.floor(Math.random() * 255)
-      const secondRandom = Math.floor(Math.random() * 255)
-      ipv4Address.value = `127.${firstRandom}.${secondRandom}.1/30`
+      const minCeiled = Math.ceil(1)
+      const maxFloored = Math.floor(255)
+      const firstRandom = Math.floor(Math.random() * (maxFloored - minCeiled) + minCeiled)
+      const secondRandom = Math.floor(Math.random() * (maxFloored - minCeiled) + minCeiled)
+      ipv4Address.value = `127.${firstRandom}.${secondRandom}.1/32`
     } else {
       ipv4Address.value = ''
     }
@@ -997,7 +999,7 @@ async function listZonesForDeviceConfig() {
             "
             v-model.trim="ipv4Address"
             :invalidMessage="t(error.ipv4Address)"
-            :disabled="loading.configure"
+            :disabled="loading.configure || logicalIfaceType == 'bond'"
             ref="ipv4AddressRef"
           >
             <template v-if="logicalIfaceType === 'bond'" #tooltip>

--- a/src/components/standalone/interfaces_and_devices/DeleteAliasModal.vue
+++ b/src/components/standalone/interfaces_and_devices/DeleteAliasModal.vue
@@ -89,7 +89,7 @@ async function deleteAlias() {
     primaryButtonKind="danger"
     :primaryButtonDisabled="loading.deleteAlias"
     :primaryButtonLoading="loading.deleteAlias"
-    :closeAriaLabe="t('common.close')"
+    :closeAriaLabel="t('common.close')"
     @close="closeModal"
     @primaryClick="deleteAlias"
   >

--- a/src/components/standalone/interfaces_and_devices/DeleteBondModal.vue
+++ b/src/components/standalone/interfaces_and_devices/DeleteBondModal.vue
@@ -9,9 +9,10 @@ const { t } = useI18n()
 // using changes store there because all view does so
 const changeStore = useUciPendingChangesStore()
 
-const props = defineProps<{
-  bond?: string
-}>()
+const props = defineProps({
+  visible: { type: Boolean, default: false },
+  bond: { type: String, default: '' }
+})
 
 const emit = defineEmits(['close', 'success'])
 
@@ -65,7 +66,7 @@ function handleClose() {
     :secondary-button-disabled="loading"
     :secondary-button-loading="loading"
     :title="t('standalone.interfaces_and_devices.delete_bond_title', { name: computedBond })"
-    :visible="bond != undefined"
+    :visible="visible"
     kind="warning"
     @close="handleClose"
     @primaryClick="submit"

--- a/src/components/standalone/interfaces_and_devices/DeleteBondModal.vue
+++ b/src/components/standalone/interfaces_and_devices/DeleteBondModal.vue
@@ -1,0 +1,86 @@
+<script lang="ts" setup>
+import { getAxiosErrorMessage, NeInlineNotification, NeModal } from '@nethserver/vue-tailwind-lib'
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { ubusCall } from '@/lib/standalone/ubus'
+import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
+
+const { t } = useI18n()
+// using changes store there because all view does so
+const changeStore = useUciPendingChangesStore()
+
+const props = defineProps<{
+  bond?: string
+}>()
+
+const emit = defineEmits(['close', 'success'])
+
+const loading = ref(false)
+const error = ref<Error>()
+const computedBond = ref<typeof props.bond>()
+
+watch(
+  () => props.bond,
+  (value) => {
+    if (value) {
+      computedBond.value = value
+    }
+  }
+)
+
+function submit() {
+  loading.value = true
+  error.value = undefined
+  ubusCall('ns.devices', 'delete-bond', {
+    name: computedBond.value
+  })
+    .then(() => {
+      changeStore.getChanges()
+      emit('success')
+    })
+    .catch((reason: Error) => {
+      error.value = reason
+    })
+    .finally(() => {
+      loading.value = false
+    })
+}
+
+function handleClose() {
+  if (!loading.value) {
+    error.value = undefined
+    emit('close')
+  }
+}
+</script>
+
+<template>
+  <NeModal
+    :cancel-label="t('common.cancel')"
+    :close-aria-label="t('common.close')"
+    :primary-button-disabled="loading"
+    :primary-button-kind="'danger'"
+    :primary-button-loading="loading"
+    :primary-label="t('common.delete')"
+    :secondary-button-disabled="loading"
+    :secondary-button-loading="loading"
+    :title="t('standalone.interfaces_and_devices.delete_bond_title', { name: computedBond })"
+    :visible="bond != undefined"
+    kind="warning"
+    @close="handleClose"
+    @primaryClick="submit"
+  >
+    <div class="space-y-4">
+      <NeInlineNotification
+        v-if="error"
+        :description="t(getAxiosErrorMessage(error))"
+        :title="t('standalone.interfaces_and_devices.cannot_delete_bond')"
+        class="mt-4"
+        kind="error"
+      />
+      <p>
+        {{ t('standalone.interfaces_and_devices.delete_bond_description', { name: computedBond }) }}
+      </p>
+    </div>
+  </NeModal>
+</template>

--- a/src/components/standalone/interfaces_and_devices/DeleteDeviceModal.vue
+++ b/src/components/standalone/interfaces_and_devices/DeleteDeviceModal.vue
@@ -82,7 +82,7 @@ async function deleteDevice() {
     primaryButtonKind="danger"
     :primaryButtonDisabled="loading.deleteDevice"
     :primaryButtonLoading="loading.deleteDevice"
-    :closeAriaLabe="t('common.close')"
+    :closeAriaLabel="t('common.close')"
     @close="closeModal"
     @primaryClick="deleteDevice"
   >

--- a/src/components/standalone/interfaces_and_devices/DeviceButtons.vue
+++ b/src/components/standalone/interfaces_and_devices/DeviceButtons.vue
@@ -1,0 +1,150 @@
+<script lang="ts" setup>
+import { useI18n } from 'vue-i18n'
+import {
+  type DeviceOrIface,
+  getInterface,
+  isBond,
+  isVlan,
+  isConfiguredBond,
+  isBridge,
+  isUnconfiguredBond,
+  getAliasInterface,
+  getFirewallZone
+} from '@/lib/standalone/network'
+import type { PropType } from 'vue'
+import { NeDropdown, NeButton } from '@nethesis/vue-components'
+
+const { t } = useI18n()
+
+const props = defineProps({
+  deviceOrIface: {
+    type: Object as PropType<DeviceOrIface>,
+    required: true
+  },
+  networkConfig: {
+    type: Object,
+    required: true
+  },
+  firewallConfig: {
+    type: Object,
+    required: true
+  }
+})
+
+const emit = defineEmits([
+  'showConfigureDeviceDrawer',
+  'configureBond',
+  'showCreateAliasInterfaceDrawer',
+  'showUnconfigureDeviceModal',
+  'showDeleteBondModal',
+  'showDeleteDeviceModal'
+])
+
+function getConfiguredDeviceKebabMenuItems(device: DeviceOrIface) {
+  const iface = getInterface(device)
+
+  return [
+    {
+      id: 'createAliasInterface',
+      label: t('standalone.interfaces_and_devices.create_alias_interface'),
+      icon: 'copy',
+      iconStyle: 'fas',
+      action: () => emit('showCreateAliasInterfaceDrawer', device),
+      disabled:
+        !iface ||
+        !!getAliasInterface(device, props.networkConfig) ||
+        !getFirewallZone(iface, props.firewallConfig)
+    },
+    {
+      id: 'removeConfiguration',
+      label: isBridge(device)
+        ? t('standalone.interfaces_and_devices.delete_interface')
+        : t('standalone.interfaces_and_devices.remove_configuration'),
+      icon: 'circle-minus',
+      iconStyle: 'fas',
+      action: () => emit('showUnconfigureDeviceModal', device),
+      danger: true,
+      disabled: !iface
+    }
+  ]
+}
+
+function getUnconfiguredVlanKebabMenuItems(device: DeviceOrIface) {
+  return [
+    {
+      id: 'deleteDevice',
+      label: t('standalone.interfaces_and_devices.delete_device'),
+      icon: 'trash',
+      iconStyle: 'fas',
+      action: () => emit('showDeleteDeviceModal', device),
+      danger: true
+    }
+  ]
+}
+</script>
+
+<template>
+  <!-- reconfigure button -->
+  <NeButton
+    v-if="getInterface(deviceOrIface) && !isBond(deviceOrIface)"
+    kind="tertiary"
+    size="lg"
+    @click="emit('showConfigureDeviceDrawer', deviceOrIface)"
+  >
+    <template #prefix>
+      <font-awesome-icon :icon="['fas', 'pen-to-square']" class="h-4 w-4" aria-hidden="true" />
+    </template>
+    {{ t('common.edit') }}
+  </NeButton>
+  <!-- configure button for unconfigured bonds -->
+  <NeButton
+    v-else-if="isUnconfiguredBond(deviceOrIface)"
+    kind="secondary"
+    size="lg"
+    @click="emit('configureBond', deviceOrIface)"
+  >
+    <template #prefix>
+      <font-awesome-icon :icon="['fas', 'wrench']" class="h-4 w-4" aria-hidden="true" />
+    </template>
+    {{ t('standalone.interfaces_and_devices.configure_bond') }}
+  </NeButton>
+  <!-- configure button for non-bond unconfigured devices -->
+  <NeButton
+    v-else-if="!isBond(deviceOrIface)"
+    kind="secondary"
+    size="lg"
+    @click="emit('showConfigureDeviceDrawer', deviceOrIface)"
+  >
+    <template #prefix>
+      <font-awesome-icon :icon="['fas', 'wrench']" class="h-4 w-4" aria-hidden="true" />
+    </template>
+    {{ t('standalone.interfaces_and_devices.configure') }}
+  </NeButton>
+  <NeDropdown
+    v-if="
+      (getInterface(deviceOrIface) && !isBond(deviceOrIface)) || isConfiguredBond(deviceOrIface)
+    "
+    :items="getConfiguredDeviceKebabMenuItems(deviceOrIface)"
+    :alignToRight="true"
+  />
+  <NeDropdown
+    v-if="isUnconfiguredBond(deviceOrIface)"
+    :items="[
+      {
+        id: 'deleteBond',
+        label: t('standalone.interfaces_and_devices.delete_bond'),
+        icon: 'trash',
+        iconStyle: 'fas',
+        action: () => emit('showDeleteBondModal', deviceOrIface),
+        danger: true
+      }
+    ]"
+    :alignToRight="true"
+  />
+  <!-- actions for unconfigured vlan devices -->
+  <NeDropdown
+    v-else-if="isVlan(deviceOrIface) && !getInterface(deviceOrIface)"
+    :items="getUnconfiguredVlanKebabMenuItems(deviceOrIface)"
+    :alignToRight="true"
+  />
+</template>

--- a/src/components/standalone/interfaces_and_devices/UnconfigureDeviceModal.vue
+++ b/src/components/standalone/interfaces_and_devices/UnconfigureDeviceModal.vue
@@ -85,7 +85,7 @@ async function unconfigureDevice() {
     primaryButtonKind="danger"
     :primaryButtonDisabled="loading.unconfigureDevice"
     :primaryButtonLoading="loading.unconfigureDevice"
-    :closeAriaLabe="t('common.close')"
+    :closeAriaLabel="t('common.close')"
     @close="closeModal"
     @primaryClick="unconfigureDevice"
   >

--- a/src/components/standalone/interfaces_and_devices/UnconfigureDeviceModal.vue
+++ b/src/components/standalone/interfaces_and_devices/UnconfigureDeviceModal.vue
@@ -71,13 +71,13 @@ async function unconfigureDevice() {
   <NeModal
     :visible="visible"
     :title="
-      isBridge(device) || isBond(device)
+      isBridge(device)
         ? t('standalone.interfaces_and_devices.delete_interface')
         : t('standalone.interfaces_and_devices.remove_configuration')
     "
     kind="warning"
     :primaryLabel="
-      isBridge(device) || isBond(device)
+      isBridge(device)
         ? t('standalone.interfaces_and_devices.delete_interface')
         : t('standalone.interfaces_and_devices.remove_configuration')
     "

--- a/src/lib/standalone/network.ts
+++ b/src/lib/standalone/network.ts
@@ -290,8 +290,16 @@ export function isBridge(device: DeviceOrIface) {
   }
 }
 
-export function isBond(iface: DeviceOrIface) {
-  return iface?.proto === 'bonding' || iface.name?.startsWith('bond-')
+export function isBond(deviceOrIface: DeviceOrIface) {
+  return deviceOrIface?.proto === 'bonding' || deviceOrIface.name?.startsWith('bond-')
+}
+
+export function isUnconfiguredBond(deviceOrIface: DeviceOrIface) {
+  return isBond(deviceOrIface) && !deviceOrIface.iface
+}
+
+export function isConfiguredBond(deviceOrIface: DeviceOrIface) {
+  return isBond(deviceOrIface) && deviceOrIface.iface
 }
 
 export function isIpsec(device: DeviceOrIface) {

--- a/src/lib/standalone/network.ts
+++ b/src/lib/standalone/network.ts
@@ -24,6 +24,7 @@ export interface DeviceOrIface {
   ipaddr?: string
   packets_per_slave?: string
   slaves?: string[]
+  bond_interface?: string
   speed?: number
   zone?: string
   hotspot?: HotspotConfig
@@ -290,7 +291,7 @@ export function isBridge(device: DeviceOrIface) {
 }
 
 export function isBond(iface: DeviceOrIface) {
-  return iface?.proto === 'bonding'
+  return iface?.proto === 'bonding' || iface.name?.startsWith('bond-')
 }
 
 export function isIpsec(device: DeviceOrIface) {

--- a/src/views/standalone/network/InterfacesAndDevicesView.vue
+++ b/src/views/standalone/network/InterfacesAndDevicesView.vue
@@ -388,6 +388,9 @@ function getIpv4Addresses(device: any) {
       ipv4Addresses.push({ address: iface.ipaddr })
     }
   }
+  if (isBond(device) && ipv4Addresses.length > 0) {
+    ipv4Addresses.splice(0, 1)
+  }
   return uniqWith(ipv4Addresses, isEqual)
 }
 
@@ -733,7 +736,7 @@ function isDeviceConfigurable(deviceOrIface: DeviceOrIface) {
                           </span>
                           <span>{{ device.hotspot?.network }}</span>
                         </div>
-                        <div v-if="!isBond(device)">
+                        <div>
                           <div v-if="getIpv4Addresses(device)?.length">
                             <div v-for="(ipv4, i) in getIpv4Addresses(device)" :key="i">
                               <div>


### PR DESCRIPTION
UI is quite intricate, but here's what I've tried to accomplish so far:
- deleting the `zone` param when creating a bond, allows to configure the bond according to user preference, also removed the radio selection entirely for bonds
- bond naming is **weird** (and it's a compliment). When you define a named bond, the software first creates a `bonding-<name>` device for said bond, then when device gets up it's renamed to `bond-<name>`. IF THE `bond-<name>` EXCEEDS THE 15 CHARACTERS IT WILL BE STUCK IN THE FIRST STATE. Hence there's a custom check for bond name length.
- Added delete bond modal using custom call from API
- Due to changes in the API responses, there's an additional `bond_interface` field in the DeviceOrIface interface.
- Added additional check in `isBond` function, checking for name too. (can be change to check if there's a `bond_interface` field tho)
- Filtering out from the response the bond interfaces if there's a bond device, might be overkill now since the API already filters them.
- If you configure a bond, trick the drawer to make it believe that it's configuring a physical device with the correct device name. **NOTE**: It seems it's bugged in some way, need assistance on where it might be different from other configuration drawers.
- slicing name in rows and removing `bond-` prefix.
- few revisiting on the buttons for the rows, this might have introduced bugs, adding configure/edit/delete of bond.

Prerequisites:
- https://github.com/NethServer/nethsecurity/pull/277