### PR TITLE
Devices and interfaces: rework alias interface drawer to use NeMultiTextInput

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -730,7 +730,8 @@
       "no_devices_available": "No devices available",
       "custom_zone": "Custom",
       "cannot_remove_device_configuration": "Cannot remove device configuration",
-      "hotspot_network": "Network"
+      "hotspot_network": "Network",
+      "add_ip_address": "Add IP address"
     },
     "multi_wan": {
       "title": "MultiWAN",

--- a/src/components/standalone/NeMultiTextInput.vue
+++ b/src/components/standalone/NeMultiTextInput.vue
@@ -103,7 +103,6 @@ function updateModelKey(idx: number, newValue: string) {
 }
 
 function focus() {
-  console.log(inputRef.value)
   inputRef.value?.focus()
 }
 

--- a/src/components/standalone/NeMultiTextInput.vue
+++ b/src/components/standalone/NeMultiTextInput.vue
@@ -41,10 +41,16 @@ const props = withDefaults(
   { useKeyInput: false, required: false }
 )
 
+defineExpose({
+  focus
+})
+
 const emit = defineEmits(['delete-item', 'add-item', 'update:modelValue'])
 
 const keys = ref<string[]>([])
 const items = ref<string[]>([])
+
+const inputRef = ref()
 
 function refreshKeysAndItems() {
   items.value = [
@@ -94,6 +100,11 @@ function updateModelValue(idx: number, newValue: string) {
 function updateModelKey(idx: number, newValue: string) {
   keys.value[idx] = newValue
   emitUpdate()
+}
+
+function focus() {
+  console.log(inputRef.value)
+  inputRef.value?.focus()
 }
 
 watch(
@@ -156,6 +167,13 @@ onMounted(() => {
           :invalid-message="invalidMessages ? invalidMessages[i] : ''"
           :disabled="disableInputs"
           :placeholder="placeholder"
+          :ref="
+            (r) => {
+              if (i == 0) {
+                inputRef = r
+              }
+            }
+          "
         />
         <NeButton kind="tertiary" size="md" @click="deleteItem(i)" :disabled="i === 0 && required">
           <font-awesome-icon :icon="['fas', 'trash']" class="h-4 w-4 py-1" aria-hidden="true" />


### PR DESCRIPTION
- Use NeMultiTextInput on the create/edit alias interface drawer to maintain uniformity
- Simplify validation with the new inputs in mind
- Add option, in NeMultiTextInput, to focus on the first text-input if available

Card: https://trello.com/c/9OWsVjah/222-devices-and-interfaces-alias-improvement-ui