### PR TITLE
Update page: avoid showing error notification on system reboot, minor UI fixes

### DIFF
--- a/src/StandaloneApp.vue
+++ b/src/StandaloneApp.vue
@@ -124,9 +124,16 @@ function configureAxios() {
       } else {
         // show error notification only if error is not caused from cancellation
         // and if it isn't a validation error
+        // and if it isn't caused by one of the update endpoints because of the system rebooting (causing a net::ERR_CONNECTION_REFUSED)
         if (
           !(error instanceof CanceledError) &&
-          !error.response?.data?.data?.validation?.errors?.length
+          !error.response?.data?.data?.validation?.errors?.length &&
+          !(
+            error.config.url.includes('/ubus/call') &&
+            (JSON.parse(error.config.data)?.method === 'install-uploaded-image' ||
+              JSON.parse(error.config.data)?.method === 'update-system') &&
+            (!error.response || !error.response.data)
+          )
         ) {
           notificationsStore.createNotificationFromAxiosError(error)
         }

--- a/src/StandaloneApp.vue
+++ b/src/StandaloneApp.vue
@@ -124,7 +124,7 @@ function configureAxios() {
       } else {
         // show error notification only if error is not caused from cancellation
         // and if it isn't a validation error
-        // and if it isn't caused by one of the update endpoints because of the system rebooting (causing a net::ERR_CONNECTION_REFUSED)
+        // and if it isn't caused by one of the update endpoints because of the system rebooting
         if (
           !(error instanceof CanceledError) &&
           !error.response?.data?.data?.validation?.errors?.length &&
@@ -132,6 +132,7 @@ function configureAxios() {
             error.config.url.includes('/ubus/call') &&
             (JSON.parse(error.config.data)?.method === 'install-uploaded-image' ||
               JSON.parse(error.config.data)?.method === 'update-system') &&
+            // if the error is caused by a system reboot, the response will not have a payload (since it's caused by a net::ERR_CONNECTION_REFUSED)
             (!error.response || !error.response.data)
           )
         ) {

--- a/src/components/standalone/update/UpdatePackagesModal.vue
+++ b/src/components/standalone/update/UpdatePackagesModal.vue
@@ -72,10 +72,10 @@ async function updatePackages() {
     kind="info"
     :title="t('standalone.update.bug_security_fixes_to_update')"
     :primary-label="t('standalone.update.update')"
-    :primary-button-disabled="isUpdatingPackages"
-    :primary-button-loading="isUpdatingPackages"
+    :primary-button-disabled="isSubmittingUpdateRequest || isUpdatingPackages"
+    :primary-button-loading="isSubmittingUpdateRequest || isUpdatingPackages"
     :cancel-label="!isUpdatingPackages ? t('common.cancel') : ''"
-    @close="!isUpdatingPackages ? close() : undefined"
+    @close="!isUpdatingPackages && !isSubmittingUpdateRequest ? close() : undefined"
     @primary-click="updatePackages"
   >
     <div class="max-h-96 overflow-y-scroll">

--- a/src/components/standalone/update/UpdatePackagesModal.vue
+++ b/src/components/standalone/update/UpdatePackagesModal.vue
@@ -78,7 +78,7 @@ async function updatePackages() {
     @close="!isUpdatingPackages && !isSubmittingUpdateRequest ? close() : undefined"
     @primary-click="updatePackages"
   >
-    <div class="max-h-96 overflow-y-scroll">
+    <div class="max-h-96 overflow-y-auto">
       <template v-if="!isUpdatingPackages"
         ><p v-for="item in packageUpdates" :key="item.package">
           {{ item.package }}

--- a/src/components/standalone/update/UpdatePackagesModal.vue
+++ b/src/components/standalone/update/UpdatePackagesModal.vue
@@ -78,32 +78,34 @@ async function updatePackages() {
     @close="!isUpdatingPackages ? close() : undefined"
     @primary-click="updatePackages"
   >
-    <template v-if="!isUpdatingPackages"
-      ><p v-for="item in packageUpdates" :key="item.package">
-        {{ item.package }}
-        <span class="text-gray-500 dark:text-gray-400">{{
-          t('standalone.update.component_update_details', {
-            versionFrom: item.currentVersion,
-            versionTo: item.lastVersion
-          })
-        }}</span>
-      </p>
-      <NeInlineNotification
-        v-if="error.notificationDescription"
-        :title="t('error.cannot_update_packages')"
-        :description="error.notificationDescription"
-        class="my-6"
-        kind="error"
-        ><template #details v-if="error.notificationDetails">
-          {{ error.notificationDetails }}
-        </template></NeInlineNotification
-      ></template
-    >
-    <template v-else>
-      <p>
-        {{ t('standalone.update.update_in_progress_message') }}
-      </p>
-      <NeProgressBar class="mt-4" :progress="currentProgress" />
-    </template>
+    <div class="max-h-96 overflow-y-scroll">
+      <template v-if="!isUpdatingPackages"
+        ><p v-for="item in packageUpdates" :key="item.package">
+          {{ item.package }}
+          <span class="text-gray-500 dark:text-gray-400">{{
+            t('standalone.update.component_update_details', {
+              versionFrom: item.currentVersion,
+              versionTo: item.latestVersion
+            })
+          }}</span>
+        </p>
+        <NeInlineNotification
+          v-if="error.notificationDescription"
+          :title="t('error.cannot_update_packages')"
+          :description="error.notificationDescription"
+          class="my-6"
+          kind="error"
+          ><template #details v-if="error.notificationDetails">
+            {{ error.notificationDetails }}
+          </template></NeInlineNotification
+        ></template
+      >
+      <template v-else>
+        <p>
+          {{ t('standalone.update.update_in_progress_message') }}
+        </p>
+        <NeProgressBar class="mt-4" :progress="currentProgress" />
+      </template>
+    </div>
   </NeModal>
 </template>

--- a/src/views/standalone/system/UpdateView.vue
+++ b/src/views/standalone/system/UpdateView.vue
@@ -22,7 +22,7 @@ import { getProductName } from '@/lib/config'
 export type PackageUpdate = {
   package: string
   currentVersion: string
-  lastVersion: string
+  latestVersion: string
 }
 
 export type SystemUpdate = {


### PR DESCRIPTION
- Avoid showing toast notification when the system is rebooting because of a system update
- Fix incorrect package payload field (`latestVersion` instead of `lastVersion`)
- Add maximum height and overflow scroll on package updates drawer, to avoid cases where it is expanded too much when there are many packages to upload
- Fix buttons in package updates drawer not being disabled properly when making an update request

Card: https://trello.com/c/2gT1g47F/227-update-page-notification-error-while-updating-rebooting