### PR TITLE
Reverse proxy: avoid showing unobtained certificates when creating or editing domains

### DIFF
--- a/src/components/standalone/reverse_proxy/CreateOrEditProxyDrawer.vue
+++ b/src/components/standalone/reverse_proxy/CreateOrEditProxyDrawer.vue
@@ -193,10 +193,12 @@ async function fetchOptions() {
   try {
     const certificatesData = (await ubusCall('ns.reverseproxy', 'list-certificates')).data.values
     certificateOptions.value = [
-      ...Object.keys(certificatesData).map((x: string) => ({
-        id: x,
-        label: x === '_lan' ? t('standalone.reverse_proxy.default_certificate') : x
-      }))
+      ...Object.keys(certificatesData)
+        .filter((x) => !certificatesData[x].pending)
+        .map((x) => ({
+          id: x,
+          label: x === '_lan' ? t('standalone.reverse_proxy.default_certificate') : x
+        }))
     ]
   } catch (err: any) {
     error.value.notificationTitle = t('error.cannot_retrieve_certificates')


### PR DESCRIPTION
- Avoid showing pending certificates in create/edit proxy drawer 

Card: https://trello.com/c/Eo4w1OXj/291-reverseproxy-ui-shows-unobtained-certificates-when-creating-or-editing-domains