### PR TITLE
Reverse proxy: use new URL validation for destination url

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -555,12 +555,12 @@ export const validateIpAddressOrFQDN = (value: string) => {
 }
 
 export const validateURL = (value: string): validationOutput => {
-  const re = /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)?/gi
-
-  if (!value.match(re)) {
+  try {
+    new URL(value)
+    return { valid: true }
+  } catch {
     return { valid: false, errMessage: 'error.invalid_url' }
   }
-  return { valid: true }
 }
 
 export const validateLDAPUri = (value: string): validationOutput => {


### PR DESCRIPTION
- Use new URL validator for destination URL, allowing for the usage of domains such as `http(s)://localhost`. The new validator makes use of Javascript's `URL` object instead of relying on a regex, allowing for more flexibility in the URL definition.

Card: https://trello.com/c/mCck9st8/293-reverse-proxy-ui-doesnt-accept-localhost-as-destination-url