### PR TITLE
OpenVPN Tunnel: use host validation for remote hosts instead of ip

### DIFF
--- a/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
@@ -7,6 +7,7 @@
 import { ref, toRefs, watch } from 'vue'
 import {
   MessageBag,
+  validateHost,
   validateIp4Cidr,
   validateIpAddress,
   validateIpAddressOrFQDN,
@@ -439,7 +440,7 @@ function validate() {
     // remote hosts validation
     let validRemoteHosts = true
     for (let [index, remoteHost] of remoteHosts.value.entries()) {
-      let validators = [validateRequired(remoteHost), validateIpAddress(remoteHost)]
+      let validators = [validateRequired(remoteHost), validateHost(remoteHost)]
       for (let validator of validators) {
         if (!validator.valid) {
           remoteHostsValidationErrors.value[index] = t(validator.errMessage as string)


### PR DESCRIPTION
- Use host validation for remote hosts, allowing for IP or hostnames (instead of allowing only IPs)

Card: https://trello.com/c/6jA5ZsZd/295-openvpn-tunnels-cant-use-an-hostname-inside-the-remote-hosts-field