### PR TITLE
Certificates: allow wildcard domains when requesting a Let's Encrypt certificate

### DIFF
--- a/src/components/standalone/certificates/CreateLetsEncryptCertificateDrawer.vue
+++ b/src/components/standalone/certificates/CreateLetsEncryptCertificateDrawer.vue
@@ -136,7 +136,7 @@ function validate() {
   let validDomains = true
   for (let [index, domain] of domains.value.entries()) {
     if (domain) {
-      let validator = validateFQDN(domain, true)
+      let validator = validateFQDN(domain, validationMethod.value === 'dns')
       if (!validator.valid) {
         domainValidationErrors.value[index] = t(validator.errMessage as string)
         validDomains = false

--- a/src/components/standalone/certificates/CreateLetsEncryptCertificateDrawer.vue
+++ b/src/components/standalone/certificates/CreateLetsEncryptCertificateDrawer.vue
@@ -136,7 +136,7 @@ function validate() {
   let validDomains = true
   for (let [index, domain] of domains.value.entries()) {
     if (domain) {
-      let validator = validateFQDN(domain)
+      let validator = validateFQDN(domain, true)
       if (!validator.valid) {
         domainValidationErrors.value[index] = t(validator.errMessage as string)
         validDomains = false

--- a/src/components/standalone/reverse_proxy/CreateOrEditProxyDrawer.vue
+++ b/src/components/standalone/reverse_proxy/CreateOrEditProxyDrawer.vue
@@ -117,7 +117,7 @@ function validate() {
     [[validateRequired(path.value), validatePath(path.value)], 'path']
   ]
   const domainValidators: [validationOutput[], string][] = [
-    [[validateRequired(domain.value), validateFQDN(domain.value)], 'domain']
+    [[validateRequired(domain.value), validateFQDN(domain.value, false)], 'domain']
   ]
   const validators: [validationOutput[], string][] = [
     [[validateRequired(destinationURL.value), validateURL(destinationURL.value)], 'destination'],

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -534,8 +534,10 @@ export const validatePath = (value: string): validationOutput => {
   return { valid: true }
 }
 
-export const validateFQDN = (value: string): validationOutput => {
-  const re = /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)/
+export const validateFQDN = (value: string, acceptWildcard: boolean): validationOutput => {
+  const re = acceptWildcard
+    ? /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-*]{1,63}(?<!-)\.)+[a-zA-Z*]{1,63}$)/
+    : /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)/
 
   if (!value.match(re)) {
     return { valid: false, errMessage: 'error.invalid_fqdn' }
@@ -545,7 +547,7 @@ export const validateFQDN = (value: string): validationOutput => {
 
 export const validateIpAddressOrFQDN = (value: string) => {
   const ipValidator = validateIpAddress(value)
-  const fqdnValidator = validateFQDN(value)
+  const fqdnValidator = validateFQDN(value, false)
 
   if (!ipValidator.valid && !fqdnValidator.valid) {
     return { valid: false, errMessage: 'error.invalid_ip_address_or_fqdn' }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -536,7 +536,7 @@ export const validatePath = (value: string): validationOutput => {
 
 export const validateFQDN = (value: string, acceptWildcard: boolean): validationOutput => {
   const re = acceptWildcard
-    ? /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-*]{1,63}(?<!-)\.)+[a-zA-Z*]{1,63}$)/
+    ? /(?=^.{4,253}$)(^(\*\.)?((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)/
     : /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)/
 
   if (!value.match(re)) {


### PR DESCRIPTION
- Allow usage of wildcard domains when requesting a Let's Encrypt certificate, done by adding an additional argument in the FQDN validator, which can be used to allow or disallow the usage of wildcards

Card: https://trello.com/c/Yl5g0dEC/297-certificates-validation-error-for-wildcard-domains