### PR TITLE
DNS & DHCP: allow the creation of static leases from dynamic leases, various ui improvements

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -50,6 +50,7 @@
     "cannot_load_network_interfaces": "Cannot load network interfaces",
     "invalid_host": "Invalid host: must be a hostname or an IP address",
     "invalid_mac_address": "Invalid MAC address",
+    "mac_already_reserved": "MAC address has already been reserved",
     "invalid_ip_address": "Invalid IP address",
     "invalid_ip_v4_address": "Invalid IPv4 address",
     "invalid_ip_v6_address": "Invalid IPv6 address",

--- a/src/components/standalone/FilterableListItemLayout.vue
+++ b/src/components/standalone/FilterableListItemLayout.vue
@@ -34,7 +34,8 @@ const { t } = useI18n()
 const loading = ref(false)
 const error = ref({
   notificationTitle: '',
-  notificationDescription: ''
+  notificationDescription: '',
+  notificationDetails: ''
 })
 const items = ref<T[]>([]) as Ref<T[]>
 
@@ -57,6 +58,7 @@ async function fetchItems() {
   } catch (err: any) {
     error.value.notificationTitle = props.fetchErrorNotificationTitle
     error.value.notificationDescription = t(getAxiosErrorMessage(err))
+    error.value.notificationDetails = err.toString()
   }
 }
 
@@ -115,7 +117,11 @@ onMounted(() => {
       :title="error.notificationTitle"
       :description="error.notificationDescription"
       v-if="error.notificationDescription"
-    />
+    >
+      <template #details v-if="error.notificationDetails">
+        {{ error.notificationDetails }}
+      </template>
+    </NeInlineNotification>
     <NeSkeleton v-if="loading" :lines="10" />
     <template v-else>
       <NeEmptyState

--- a/src/components/standalone/dns_dhcp/CreateOrEditDnsRecordDrawer.vue
+++ b/src/components/standalone/dns_dhcp/CreateOrEditDnsRecordDrawer.vue
@@ -40,7 +40,8 @@ const emit = defineEmits(['close', 'add-edit-record'])
 const isSavingChanges = ref(false)
 const error = ref({
   notificationTitle: '',
-  notificationDescription: ''
+  notificationDescription: '',
+  notificationDetails: ''
 })
 const validationErrorBag = ref(new MessageBag())
 
@@ -85,6 +86,8 @@ function validate() {
 async function createOrEditDnsRecord() {
   error.value.notificationTitle = ''
   error.value.notificationDescription = ''
+  error.value.notificationDetails = ''
+
   const isEditing = id.value != ''
 
   try {
@@ -122,6 +125,8 @@ async function createOrEditDnsRecord() {
       err.response.data.message == 'record_not_found'
         ? t('standalone.dns_dhcp.record_not_found')
         : t(getAxiosErrorMessage(err))
+
+    error.value.notificationDetails = err.toString()
   } finally {
     isSavingChanges.value = false
   }
@@ -131,6 +136,7 @@ function close() {
   validationErrorBag.value.clear()
   error.value.notificationTitle = ''
   error.value.notificationDescription = ''
+  error.value.notificationDetails = ''
   resetForm()
   emit('close')
 }
@@ -157,7 +163,11 @@ onMounted(() => {
       :description="error.notificationDescription"
       class="mb-6"
       kind="error"
-    />
+    >
+      <template #details v-if="error.notificationDetails">
+        {{ error.notificationDetails }}
+      </template>
+    </NeInlineNotification>
     <div class="flex flex-col gap-y-6">
       <NeTextInput
         v-model="hostname"

--- a/src/components/standalone/dns_dhcp/CreateOrEditStaticLeaseDrawer.vue
+++ b/src/components/standalone/dns_dhcp/CreateOrEditStaticLeaseDrawer.vue
@@ -41,7 +41,8 @@ const emit = defineEmits(['close', 'add-edit-lease'])
 const isSavingChanges = ref(false)
 const error = ref({
   notificationTitle: '',
-  notificationDescription: ''
+  notificationDescription: '',
+  notificationDetails: ''
 })
 const validationErrorBag = ref(new MessageBag())
 
@@ -95,6 +96,7 @@ function validate() {
 async function createOrEditStaticLease() {
   error.value.notificationTitle = ''
   error.value.notificationDescription = ''
+  error.value.notificationDetails = ''
   const isEditing = id.value != ''
 
   try {
@@ -132,6 +134,8 @@ async function createOrEditStaticLease() {
       err.response.data.message == 'lease_not_found'
         ? t('standalone.dns_dhcp.lease_not_found')
         : t(getAxiosErrorMessage(err))
+
+    error.value.notificationDetails = err.toString()
   } finally {
     isSavingChanges.value = false
   }
@@ -141,6 +145,7 @@ function close() {
   validationErrorBag.value.clear()
   error.value.notificationTitle = ''
   error.value.notificationDescription = ''
+  error.value.notificationDetails = ''
   resetForm()
   emit('close')
 }
@@ -169,7 +174,11 @@ onMounted(() => {
       :description="error.notificationDescription"
       class="mb-6"
       kind="error"
-    />
+    >
+      <template #details v-if="error.notificationDetails">
+        {{ error.notificationDetails }}
+      </template>
+    </NeInlineNotification>
     <div class="flex flex-col gap-y-6">
       <NeTextInput
         v-model="hostname"

--- a/src/components/standalone/dns_dhcp/CreateOrEditStaticLeaseDrawer.vue
+++ b/src/components/standalone/dns_dhcp/CreateOrEditStaticLeaseDrawer.vue
@@ -25,10 +25,12 @@ import {
 import { useI18n } from 'vue-i18n'
 import { ubusCall } from '@/lib/standalone/ubus'
 import type { StaticLease } from './StaticLeases.vue'
+import type { DynamicLease } from './DynamicLeases.vue'
 
 const props = defineProps<{
   isShown: boolean
   itemToEdit: StaticLease | null
+  importDynamicLease?: DynamicLease
 }>()
 const { isShown } = toRefs(props)
 
@@ -51,11 +53,19 @@ const macAddress = ref('')
 const reservationName = ref('')
 
 function resetForm() {
-  id.value = props.itemToEdit?.lease ?? ''
-  hostname.value = props.itemToEdit?.hostname ?? ''
-  ipAddress.value = props.itemToEdit?.ipaddr ?? ''
-  macAddress.value = props.itemToEdit?.macaddr ?? ''
-  reservationName.value = props.itemToEdit?.description ?? ''
+  if (props.importDynamicLease) {
+    id.value = ''
+    hostname.value = props.importDynamicLease.hostname
+    ipAddress.value = props.importDynamicLease.ipaddr
+    macAddress.value = props.importDynamicLease.macaddr
+    reservationName.value = ''
+  } else {
+    id.value = props.itemToEdit?.lease ?? ''
+    hostname.value = props.itemToEdit?.hostname ?? ''
+    ipAddress.value = props.itemToEdit?.ipaddr ?? ''
+    macAddress.value = props.itemToEdit?.macaddr ?? ''
+    reservationName.value = props.itemToEdit?.description ?? ''
+  }
 }
 
 function runValidators(validators: validationOutput[], label: string): boolean {

--- a/src/components/standalone/dns_dhcp/DhcpManager.vue
+++ b/src/components/standalone/dns_dhcp/DhcpManager.vue
@@ -39,7 +39,10 @@ const uciChangesStore = useUciPendingChangesStore()
 const firewallConfig = useFirewallStore()
 
 const loading = ref(true)
-const error = ref('')
+const error = ref({
+  notificationDescription: '',
+  notificationDetails: ''
+})
 const selectedInterface = ref<string>('')
 const showEditInterfaceDrawer = ref(false)
 const interfaces = ref<Record<string, DhcpInterface>>({})
@@ -58,7 +61,8 @@ async function fetchDhcpInterfaces() {
     )
     loading.value = false
   } catch (err: any) {
-    error.value = t(getAxiosErrorMessage(err))
+    error.value.notificationDescription = t(getAxiosErrorMessage(err))
+    error.value.notificationDetails = err.toString()
   }
 }
 
@@ -109,9 +113,17 @@ onMounted(() => {
         ? t('error.cannot_retrieve_zones')
         : t('error.cannot_retrieve_dhcp_interfaces')
     "
-    :description="firewallConfig.error ? t(getAxiosErrorMessage(firewallConfig.error)) : error"
+    :description="
+      firewallConfig.error
+        ? t(getAxiosErrorMessage(firewallConfig.error))
+        : error.notificationDescription
+    "
     v-if="error || firewallConfig.error"
-  />
+  >
+    <template #details v-if="error.notificationDetails || firewallConfig.error">
+      {{ firewallConfig.error ? firewallConfig.error.toString() : error.notificationDetails }}
+    </template>
+  </NeInlineNotification>
   <NeSkeleton :lines="10" v-if="loading || firewallConfig.loading" />
   <template v-else-if="!firewallConfig.error">
     <div class="mb-4 flex flex-row items-center justify-between">

--- a/src/components/standalone/dns_dhcp/DhcpManager.vue
+++ b/src/components/standalone/dns_dhcp/DhcpManager.vue
@@ -118,7 +118,7 @@ onMounted(() => {
         ? t(getAxiosErrorMessage(firewallConfig.error))
         : error.notificationDescription
     "
-    v-if="error || firewallConfig.error"
+    v-if="error.notificationDescription || firewallConfig.error"
   >
     <template #details v-if="error.notificationDetails || firewallConfig.error">
       {{ firewallConfig.error ? firewallConfig.error.toString() : error.notificationDetails }}

--- a/src/components/standalone/dns_dhcp/DhcpManager.vue
+++ b/src/components/standalone/dns_dhcp/DhcpManager.vue
@@ -83,9 +83,12 @@ function closeEditInterfaceDrawer() {
 }
 
 function toggleExpandAllCards() {
+  let newInterfaceCardExpandedValues: Record<string, boolean> = {}
   for (let key of Object.keys(isInterfaceCardExpanded.value)) {
-    isInterfaceCardExpanded.value[key] = areAllCardsExpanded.value ? false : true
+    newInterfaceCardExpandedValues[key] = areAllCardsExpanded.value ? false : true
   }
+
+  isInterfaceCardExpanded.value = newInterfaceCardExpandedValues
 }
 
 function toggleExpandSingleCard(interfaceName: string) {

--- a/src/components/standalone/dns_dhcp/DnsManager.vue
+++ b/src/components/standalone/dns_dhcp/DnsManager.vue
@@ -32,7 +32,8 @@ const uciChangesStore = useUciPendingChangesStore()
 const loading = ref(true)
 const error = ref({
   notificationTitle: '',
-  notificationDescription: ''
+  notificationDescription: '',
+  notificationDetails: ''
 })
 const isUpdatingDnsConfig = ref(false)
 
@@ -89,12 +90,14 @@ async function fetchDnsConfig() {
   } catch (err: any) {
     error.value.notificationTitle = t('error.cannot_retrieve_dns_configuration')
     error.value.notificationDescription = t(getAxiosErrorMessage(err))
+    error.value.notificationDetails = err.toString()
   }
 }
 
 async function updateDnsConfig() {
   error.value.notificationTitle = ''
   error.value.notificationDescription = ''
+  error.value.notificationDetails = ''
 
   if (!validate()) {
     return
@@ -111,6 +114,7 @@ async function updateDnsConfig() {
   } catch (err: any) {
     error.value.notificationTitle = t('error.cannot_update_dns_configuration')
     error.value.notificationDescription = t(getAxiosErrorMessage(err))
+    error.value.notificationDetails = err.toString()
   } finally {
     isUpdatingDnsConfig.value = false
   }
@@ -128,7 +132,11 @@ onMounted(() => {
       v-if="error.notificationTitle"
       :title="error.notificationTitle"
       :description="error.notificationDescription"
-    />
+    >
+      <template #details v-if="error.notificationDetails">
+        {{ error.notificationDetails }}
+      </template>
+    </NeInlineNotification>
     <NeSkeleton v-if="loading" :lines="15" />
     <template v-else>
       <NeMultiTextInput

--- a/src/components/standalone/dns_dhcp/DynamicLeases.vue
+++ b/src/components/standalone/dns_dhcp/DynamicLeases.vue
@@ -8,8 +8,15 @@ import { useI18n } from 'vue-i18n'
 import FilterableListItemLayout from '../FilterableListItemLayout.vue'
 import { ubusCall } from '@/lib/standalone/ubus'
 import LeasesTable from './LeasesTable.vue'
+import { ref } from 'vue'
+import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
+import { getStandaloneRoutePrefix } from '@/lib/router'
+import { useRouter } from 'vue-router'
+import CreateOrEditStaticLeaseDrawer from './CreateOrEditStaticLeaseDrawer.vue'
 
 const { t } = useI18n()
+const uciChangesStore = useUciPendingChangesStore()
+const router = useRouter()
 
 export type DynamicLease = {
   macaddr: string
@@ -18,6 +25,14 @@ export type DynamicLease = {
   interface: string
   device: string
   timestamp: string
+}
+
+const selectedLease = ref<DynamicLease>()
+const showCreateStaticLeaseDrawer = ref(false)
+
+function openCreateStaticLeaseDrawer(item: DynamicLease) {
+  selectedLease.value = item
+  showCreateStaticLeaseDrawer.value = true
 }
 
 async function fetchDynamicLeases(): Promise<DynamicLease[]> {
@@ -48,7 +63,24 @@ function applyFilterToDynamicLeases(dynamicLeases: DynamicLease[], filter: strin
     :description="t('standalone.dns_dhcp.dynamic_leases_description')"
   >
     <template #item-list-view="{ items }">
-      <LeasesTable :leases="items" :show-dynamic-leases="true" />
+      <LeasesTable
+        :leases="items"
+        :show-dynamic-leases="true"
+        @create-static-lease-from-dynamic="openCreateStaticLeaseDrawer"
+      />
     </template>
   </FilterableListItemLayout>
+  <CreateOrEditStaticLeaseDrawer
+    :is-shown="showCreateStaticLeaseDrawer"
+    :import-dynamic-lease="selectedLease"
+    :item-to-edit="null"
+    @close="showCreateStaticLeaseDrawer = false"
+    @add-edit-lease="
+      () => {
+        showCreateStaticLeaseDrawer = false
+        uciChangesStore.getChanges()
+        router.push(`${getStandaloneRoutePrefix()}/network/dns-dhcp?tab=static-leases`)
+      }
+    "
+  />
 </template>

--- a/src/components/standalone/dns_dhcp/EditDhcpInterfaceDrawer.vue
+++ b/src/components/standalone/dns_dhcp/EditDhcpInterfaceDrawer.vue
@@ -42,7 +42,8 @@ const isSavingChanges = ref(false)
 const loading = ref(true)
 const error = ref({
   notificationTitle: '',
-  notificationDescription: ''
+  notificationDescription: '',
+  notificationDetails: ''
 })
 const validationErrorBag = ref(new MessageBag())
 const dhcpOptionValueErrors = ref<string[]>([])
@@ -82,6 +83,7 @@ async function resetForm() {
         err.response.data.message == 'interface_not_found'
           ? t('standalone.dns_dhcp.interface_not_found')
           : t(getAxiosErrorMessage(err))
+      error.value.notificationDetails = err.toString()
     }
   } else {
     iface.value = ''
@@ -117,6 +119,7 @@ async function loadDhcpOptions() {
   } catch (err: any) {
     error.value.notificationTitle = t('error.cannot_retrieve_dhcp_options')
     error.value.notificationDescription = t(getAxiosErrorMessage(err))
+    error.value.notificationDetails = err.toString()
   }
 }
 
@@ -171,6 +174,7 @@ function validate() {
 async function saveChanges() {
   error.value.notificationTitle = ''
   error.value.notificationDescription = ''
+  error.value.notificationDetails = ''
 
   try {
     isSavingChanges.value = true
@@ -196,6 +200,7 @@ async function saveChanges() {
         err.response.data.message == 'interface_not_found'
           ? t('standalone.dns_dhcp.interface_not_found')
           : t(getAxiosErrorMessage(err))
+      error.value.notificationDetails = err.toString()
     }
   } finally {
     isSavingChanges.value = false
@@ -206,6 +211,7 @@ function close() {
   validationErrorBag.value.clear()
   error.value.notificationTitle = ''
   error.value.notificationDescription = ''
+  error.value.notificationDetails = ''
   dhcpOptionValueErrors.value = []
   dhcpOptionKeyErrors.value = []
   emit('close')
@@ -247,7 +253,11 @@ watch(
       :description="error.notificationDescription"
       class="mb-6"
       kind="error"
-    />
+    >
+      <template #details v-if="error.notificationDetails">
+        {{ error.notificationDetails }}
+      </template></NeInlineNotification
+    >
     <NeSkeleton :lines="10" v-if="loading" />
     <div v-else class="flex flex-col gap-y-6">
       <NeToggle v-model="enableDhcp" :label="t('standalone.dns_dhcp.enable_dhcp')" />

--- a/src/components/standalone/dns_dhcp/EditDhcpInterfaceDrawer.vue
+++ b/src/components/standalone/dns_dhcp/EditDhcpInterfaceDrawer.vue
@@ -98,7 +98,7 @@ async function resetForm() {
 function runValidators(validators: validationOutput[], label: string): boolean {
   for (let validator of validators) {
     if (!validator.valid) {
-      validationErrorBag.value.set(label, [t(validator.errMessage as string)])
+      validationErrorBag.value.set(label, [validator.errMessage as string])
     }
   }
 
@@ -157,9 +157,9 @@ function validate() {
   }
 
   const validators: [validationOutput[], string][] = [
-    [[validateRequired(rangeIpStart.value), validateIpAddress(rangeIpStart.value)], 'rangeIpStart'],
-    [[validateRequired(rangeIpEnd.value), validateIpAddress(rangeIpEnd.value)], 'rangeIpEnd'],
-    [[validateRequired(leaseTime.value), validateLeaseTime(leaseTime.value)], 'leaseTime']
+    [[validateRequired(rangeIpStart.value), validateIpAddress(rangeIpStart.value)], 'first'],
+    [[validateRequired(rangeIpEnd.value), validateIpAddress(rangeIpEnd.value)], 'last'],
+    [[validateRequired(leaseTime.value), validateLeaseTime(leaseTime.value)], 'leasetime']
   ]
 
   return (
@@ -217,15 +217,6 @@ function close() {
   emit('close')
 }
 
-function rangeEndValidationError() {
-  let server_error = validationErrorBag.value.getFirstFor('last')
-  if (server_error) {
-    return t('error.' + server_error)
-  } else {
-    return validationErrorBag.value.getFirstFor('rangeIpEnd')
-  }
-}
-
 watchEffect(() => {
   resetForm()
 })
@@ -264,17 +255,17 @@ watch(
       <NeTextInput
         v-model="rangeIpStart"
         :label="t('standalone.dns_dhcp.range_ip_start')"
-        :invalid-message="validationErrorBag.getFirstFor('rangeIpStart')"
+        :invalid-message="t(validationErrorBag.getFirstI18nKeyFor('first'))"
       />
       <NeTextInput
         v-model="rangeIpEnd"
         :label="t('standalone.dns_dhcp.range_ip_end')"
-        :invalid-message="rangeEndValidationError()"
+        :invalid-message="t(validationErrorBag.getFirstI18nKeyFor('last'))"
       />
       <NeTextInput
         v-model="leaseTime"
         :label="t('standalone.dns_dhcp.lease_time')"
-        :invalid-message="validationErrorBag.getFirstFor('leaseTime')"
+        :invalid-message="t(validationErrorBag.getFirstI18nKeyFor('leasetime'))"
         ><template #tooltip>
           <NeTooltip>
             <template #content>

--- a/src/components/standalone/dns_dhcp/LeasesTable.vue
+++ b/src/components/standalone/dns_dhcp/LeasesTable.vue
@@ -18,7 +18,7 @@ const props = defineProps<{
   showDynamicLeases: boolean
 }>()
 
-const emit = defineEmits(['lease-delete', 'lease-edit'])
+const emit = defineEmits(['lease-delete', 'lease-edit', 'create-static-lease-from-dynamic'])
 
 const tableHeaders = [
   {
@@ -46,33 +46,44 @@ const tableHeaders = [
     key: 'macaddr'
   },
   ...(!props.showDynamicLeases
-    ? [
-        {
-          label: '',
-          key: 'menu'
-        }
-      ]
+    ? []
     : [
         {
           label: t('standalone.dns_dhcp.lease_expiration'),
           key: 'timestamp'
         }
-      ])
+      ]),
+  {
+    label: '',
+    key: 'menu'
+  }
 ]
 
 function getDropdownItems(item: StaticLease) {
-  return [
-    {
-      id: 'delete',
-      label: t('common.delete'),
-      iconStyle: 'fas',
-      icon: 'trash',
-      danger: true,
-      action: () => {
-        emit('lease-delete', item)
-      }
-    }
-  ]
+  return !props.showDynamicLeases
+    ? [
+        {
+          id: 'delete',
+          label: t('common.delete'),
+          iconStyle: 'fas',
+          icon: 'trash',
+          danger: true,
+          action: () => {
+            emit('lease-delete', item)
+          }
+        }
+      ]
+    : [
+        {
+          id: 'create-static-lease',
+          label: t('standalone.dns_dhcp.add_reservation'),
+          iconStyle: 'fas',
+          icon: 'circle-plus',
+          action: () => {
+            emit('create-static-lease-from-dynamic', item)
+          }
+        }
+      ]
 }
 </script>
 
@@ -89,9 +100,9 @@ function getDropdownItems(item: StaticLease) {
       {{ new Date(Number.parseInt(item.timestamp) * 1000).toLocaleDateString() }}
       {{ new Date(Number.parseInt(item.timestamp) * 1000).toLocaleTimeString() }}
     </template>
-    <template v-if="!showDynamicLeases" #menu="{ item }: { item: StaticLease }">
+    <template #menu="{ item }: { item: StaticLease }">
       <div class="align-center flex justify-end">
-        <NeButton kind="tertiary" @click="emit('lease-edit', item)">
+        <NeButton v-if="!showDynamicLeases" kind="tertiary" @click="emit('lease-edit', item)">
           <template #prefix>
             <font-awesome-icon
               :icon="['fas', 'pen-to-square']"


### PR DESCRIPTION
- Allow the creation of static leases from dynamic leases
- Improve error handling of current DNS & DHCP pages
- Improve handling of remote validation errors when editing DHCP interfaces and creating or removing static leases
- Fix issue where all cards wouldn't expand correctly in the DHCP Manager

Card: https://trello.com/c/3vNdP6kA/225-dns-and-dhcp-create-static-lease-from-a-dynamic-one