### PR TITLE
fix: ifaces configured on deleted zones

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -714,6 +714,7 @@
       "zone_label_wan": "WAN (Red)",
       "zone_label_guests": "GUESTS (Blue)",
       "zone_label_dmz": "DMZ (Orange)",
+      "zone_label_unknown": "Unknown",
       "zone_label_unassigned": "Unassigned",
       "create_logical_interface": "Configure logical interface",
       "bridge": "Bridge",

--- a/src/lib/standalone/network.ts
+++ b/src/lib/standalone/network.ts
@@ -141,6 +141,7 @@ export function getZoneColor(zoneName: string) {
       return 'Orange'
     case 'hotspot':
     case 'vpn':
+    case 'unknown':
     case 'unassigned':
       return ''
     default:
@@ -158,6 +159,7 @@ export function getZoneColorClasses(zoneName: string) {
     case 'guests':
       return 'bg-blue-100 text-blue-700 dark:bg-blue-700 dark:text-blue-50'
     case 'dmz':
+    case 'unknown':
       return 'bg-amber-100 text-amber-700 dark:bg-amber-700 dark:text-amber-50'
     case 'hotspot':
       return 'bg-sky-100 text-sky-700 dark:bg-sky-700 dark:text-sky-50'
@@ -182,6 +184,7 @@ export function getZoneBorderColorClasses(zoneName: string) {
     case 'guests':
       return 'border-blue-700 dark:border-blue-700'
     case 'dmz':
+    case 'unknown':
       return 'border-amber-700 dark:border-amber-700'
     case 'hotspot':
       return 'border-sky-700 dark:border-sky-700'
@@ -214,6 +217,8 @@ export function getZoneIcon(zoneName: string) {
       return 'globe'
     case 'unassigned':
       return 'unlock'
+    case 'unknown':
+      return 'warning'
     default:
       return 'star'
   }
@@ -232,6 +237,7 @@ export function getZoneIconBackgroundStyle(zoneName: string | undefined) {
     case 'guests':
       return 'bg-blue-100 dark:bg-blue-700'
     case 'dmz':
+    case 'unknown':
       return 'bg-amber-100 dark:bg-amber-700'
     case 'hotspot':
       return 'bg-sky-100 dark:bg-sky-700'

--- a/src/views/standalone/network/InterfacesAndDevicesView.vue
+++ b/src/views/standalone/network/InterfacesAndDevicesView.vue
@@ -254,7 +254,7 @@ function getConfiguredDeviceKebabMenuItems(device: any) {
       iconStyle: 'fas',
       action: () => showUnconfigureDeviceModal(device),
       danger: true,
-      disabled: !iface || !getFirewallZone(iface, firewallConfig.value)
+      disabled: !iface
     }
   ]
 }
@@ -285,6 +285,8 @@ function showDeleteAliasModal(alias: any, device: any) {
 }
 
 function getAliasKebabMenuItems(alias: any, device: any) {
+  const iface = getInterface(device)
+
   return [
     {
       id: 'deleteAlias',
@@ -292,7 +294,8 @@ function getAliasKebabMenuItems(alias: any, device: any) {
       icon: 'trash',
       iconStyle: 'fas',
       action: () => showDeleteAliasModal(alias, device),
-      danger: true
+      danger: true,
+      disabled: !getFirewallZone(iface, firewallConfig.value)
     }
   ]
 }
@@ -924,6 +927,7 @@ function isDeviceConfigurable(deviceOrIface: DeviceOrIface) {
                               kind="tertiary"
                               size="lg"
                               @click="showEditAliasInterfaceDrawer(alias, device)"
+                              :disabled="!getFirewallZone(getInterface(device), firewallConfig)"
                             >
                               <template #prefix>
                                 <font-awesome-icon
@@ -971,6 +975,7 @@ function isDeviceConfigurable(deviceOrIface: DeviceOrIface) {
                                 kind="tertiary"
                                 size="lg"
                                 @click="showEditAliasInterfaceDrawer(alias, device)"
+                                :disabled="!getFirewallZone(getInterface(device), firewallConfig)"
                               >
                                 <template #prefix>
                                   <font-awesome-icon


### PR DESCRIPTION
Fix display and management of interfaces configured on deleted zones:
- Interface can be reconfigured or removed
- Aliases (if any) cannot be edited or deleted

Card:
- https://trello.com/c/SAG4TmDP/304-interface-with-deleted-zone-is-blocked
 
See:
- https://github.com/NethServer/nethsecurity/pull/316
