### PR TITLE
Use migrated components

### DIFF
--- a/src/components/controller/ControllerAppLogin.vue
+++ b/src/components/controller/ControllerAppLogin.vue
@@ -4,9 +4,8 @@
 -->
 
 <script setup lang="ts">
-import { NeLink } from '@nethesis/vue-components'
+import { NeLink, NeTitle } from '@nethesis/vue-components'
 import {
-  NeTitle,
   NeButton,
   NeTextInput,
   NeInlineNotification,

--- a/src/components/standalone/NeStepper.vue
+++ b/src/components/standalone/NeStepper.vue
@@ -4,7 +4,7 @@
 -->
 
 <script setup lang="ts">
-import { NeProgressBar } from '@nethserver/vue-tailwind-lib'
+import { NeProgressBar } from '@nethesis/vue-components'
 import { range } from 'lodash-es'
 
 defineProps<{

--- a/src/components/standalone/StandaloneAppLogin.vue
+++ b/src/components/standalone/StandaloneAppLogin.vue
@@ -4,8 +4,8 @@
 -->
 
 <script setup lang="ts">
-import { NeLink } from '@nethesis/vue-components'
-import { NeTitle, NeButton, NeTextInput, NeInlineNotification } from '@nethserver/vue-tailwind-lib'
+import { NeLink, NeTitle } from '@nethesis/vue-components'
+import { NeButton, NeTextInput, NeInlineNotification } from '@nethserver/vue-tailwind-lib'
 import { useLoginStore } from '@/stores/standalone/standaloneLogin'
 import { onMounted, ref, watch } from 'vue'
 import { focusElement, getAxiosErrorMessage } from '@nethserver/vue-tailwind-lib'

--- a/src/components/standalone/UciChangesModal.vue
+++ b/src/components/standalone/UciChangesModal.vue
@@ -5,12 +5,8 @@
 
 <script setup lang="ts">
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
-import {
-  NeModal,
-  NeInlineNotification,
-  NeExpandable,
-  getAxiosErrorMessage
-} from '@nethserver/vue-tailwind-lib'
+import { NeExpandable } from '@nethesis/vue-components'
+import { NeModal, NeInlineNotification, getAxiosErrorMessage } from '@nethserver/vue-tailwind-lib'
 import { ref, watch, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -177,7 +173,7 @@ async function revertChanges() {
         :key="config"
         :title="`/etc/config/${config} (${uciChangesStore.changes[config].length})`"
         :expanded="expandedChanges[config]"
-        @setExpanded="(ev) => toggleExpand(config, ev)"
+        @setExpanded="(ev: boolean) => toggleExpand(config, ev)"
       >
         <div
           v-for="(change, index) of uciChangesStore.changes[config]"

--- a/src/components/standalone/backup_and_restore/MigrationDrawer.vue
+++ b/src/components/standalone/backup_and_restore/MigrationDrawer.vue
@@ -7,14 +7,12 @@
 import { onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ubusCall } from '@/lib/standalone/ubus'
-import { NeCombobox } from '@nethesis/vue-components'
+import { NeCombobox, NeFileInput, NeProgressBar } from '@nethesis/vue-components'
 import {
   NeModal,
   NeTitle,
   NeButton,
-  NeFileInput,
   NeSideDrawer,
-  NeProgressBar,
   NeInlineNotification,
   getAxiosErrorMessage,
   NeFormItemLabel,

--- a/src/components/standalone/backup_and_restore/MigrationDrawer.vue
+++ b/src/components/standalone/backup_and_restore/MigrationDrawer.vue
@@ -7,10 +7,9 @@
 import { onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ubusCall } from '@/lib/standalone/ubus'
-import { NeCombobox, NeFileInput, NeProgressBar } from '@nethesis/vue-components'
+import { NeCombobox, NeFileInput, NeProgressBar, NeTitle } from '@nethesis/vue-components'
 import {
   NeModal,
-  NeTitle,
   NeButton,
   NeSideDrawer,
   NeInlineNotification,

--- a/src/components/standalone/backup_and_restore/RestoreContent.vue
+++ b/src/components/standalone/backup_and_restore/RestoreContent.vue
@@ -7,10 +7,9 @@
 import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ubusCall } from '@/lib/standalone/ubus'
-import { NeCombobox, NeFileInput, NeProgressBar } from '@nethesis/vue-components'
+import { NeCombobox, NeFileInput, NeProgressBar, NeTitle } from '@nethesis/vue-components'
 import {
   NeModal,
-  NeTitle,
   NeButton,
   NeTooltip,
   NeSkeleton,

--- a/src/components/standalone/backup_and_restore/RestoreContent.vue
+++ b/src/components/standalone/backup_and_restore/RestoreContent.vue
@@ -7,7 +7,7 @@
 import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ubusCall } from '@/lib/standalone/ubus'
-import { NeCombobox } from '@nethesis/vue-components'
+import { NeCombobox, NeFileInput, NeProgressBar } from '@nethesis/vue-components'
 import {
   NeModal,
   NeTitle,
@@ -15,9 +15,7 @@ import {
   NeTooltip,
   NeSkeleton,
   NeTextInput,
-  NeFileInput,
   NeSideDrawer,
-  NeProgressBar,
   NeRadioSelection,
   NeInlineNotification,
   getAxiosErrorMessage,

--- a/src/components/standalone/backup_and_restore/SetPassphraseDrawer.vue
+++ b/src/components/standalone/backup_and_restore/SetPassphraseDrawer.vue
@@ -7,13 +7,13 @@
 import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ubusCall } from '@/lib/standalone/ubus'
+import { NeTitle } from '@nethesis/vue-components'
 import {
   getAxiosErrorMessage,
   NeButton,
   NeInlineNotification,
   NeSideDrawer,
   NeTextInput,
-  NeTitle,
   NeTooltip
 } from '@nethserver/vue-tailwind-lib'
 import { AxiosError } from 'axios'

--- a/src/components/standalone/certificates/ImportCertificateDrawer.vue
+++ b/src/components/standalone/certificates/ImportCertificateDrawer.vue
@@ -6,9 +6,9 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { NeFileInput } from '@nethesis/vue-components'
 import {
   NeSideDrawer,
-  NeFileInput,
   NeButton,
   NeInlineNotification,
   NeFormItemLabel,

--- a/src/components/standalone/dashboard/SystemInfoCard.vue
+++ b/src/components/standalone/dashboard/SystemInfoCard.vue
@@ -5,9 +5,8 @@
 
 <script setup lang="ts">
 import { ubusCall } from '@/lib/standalone/ubus'
-import { NeCard } from '@nethesis/vue-components'
+import { NeCard, NeProgressBar } from '@nethesis/vue-components'
 import {
-  NeProgressBar,
   getAxiosErrorMessage,
   formatDurationLoc,
   byteFormat1024

--- a/src/components/standalone/dns_dhcp/DhcpManager.vue
+++ b/src/components/standalone/dns_dhcp/DhcpManager.vue
@@ -5,12 +5,11 @@
 
 <script setup lang="ts">
 import { ubusCall } from '@/lib/standalone/ubus'
-import { NeBadge } from '@nethesis/vue-components'
+import { NeBadge, NeTitle } from '@nethesis/vue-components'
 import {
   getAxiosErrorMessage,
   NeInlineNotification,
   NeSkeleton,
-  NeTitle,
   NeButton,
   NeEmptyState
 } from '@nethserver/vue-tailwind-lib'

--- a/src/components/standalone/factory_reset/FactoryResetContent.vue
+++ b/src/components/standalone/factory_reset/FactoryResetContent.vue
@@ -7,12 +7,12 @@
 import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ubusCall } from '@/lib/standalone/ubus'
+import { NeProgressBar } from '@nethesis/vue-components'
 import {
   getAxiosErrorMessage,
   NeButton,
   NeInlineNotification,
   NeModal,
-  NeProgressBar,
   NeSkeleton,
   NeTextInput
 } from '@nethserver/vue-tailwind-lib'

--- a/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
+++ b/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
@@ -25,7 +25,7 @@ import {
   validateIp4Cidr
 } from '@/lib/validation'
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
-import { NeCombobox, NeCard, type NeComboboxOption } from '@nethesis/vue-components'
+import { NeCombobox, NeCard, type NeComboboxOption, NeCheckbox } from '@nethesis/vue-components'
 import {
   NeFormItemLabel,
   NeSideDrawer,
@@ -33,7 +33,6 @@ import {
   NeButton,
   NeInlineNotification,
   NeRadioSelection,
-  NeCheckbox,
   NeSkeleton,
   NeTooltip,
   focusElement,

--- a/src/components/standalone/ipsec_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/ipsec_tunnel/CreateOrEditTunnelDrawer.vue
@@ -17,7 +17,7 @@ import type { IpsecTunnel } from '@/views/standalone/vpn/IPsecTunnelView.vue'
 import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import NeStepper from '../NeStepper.vue'
-import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
+import { NeCombobox, type NeComboboxOption, NeTitle } from '@nethesis/vue-components'
 import {
   NeSideDrawer,
   NeSkeleton,
@@ -27,7 +27,6 @@ import {
   NeTooltip,
   NeRadioSelection,
   NeFormItemLabel,
-  NeTitle,
   NeInlineNotification,
   getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'

--- a/src/components/standalone/openvpn_rw/RWAccountsManager.vue
+++ b/src/components/standalone/openvpn_rw/RWAccountsManager.vue
@@ -5,9 +5,9 @@
 
 <script setup lang="ts">
 import type { RWServer, RWAccount } from '@/views/standalone/vpn/OpenvpnRoadWarriorView.vue'
+import { NeTitle } from '@nethesis/vue-components'
 import {
   NeEmptyState,
-  NeTitle,
   NeTextInput,
   NeCombobox,
   NeButton,

--- a/src/components/standalone/openvpn_tunnel/ImportConfigurationDrawer.vue
+++ b/src/components/standalone/openvpn_tunnel/ImportConfigurationDrawer.vue
@@ -6,10 +6,10 @@
 <script setup lang="ts">
 import { ubusCall } from '@/lib/standalone/ubus'
 import { validateFile } from '@/lib/validation'
+import { NeFileInput } from '@nethesis/vue-components'
 import {
   NeSideDrawer,
   NeButton,
-  NeFileInput,
   NeInlineNotification,
   getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'

--- a/src/components/standalone/routes/RoutesContent.vue
+++ b/src/components/standalone/routes/RoutesContent.vue
@@ -6,12 +6,11 @@
 <script lang="ts" setup>
 import { useI18n } from 'vue-i18n'
 import { onMounted, ref } from 'vue'
-import { NeDropdown } from '@nethesis/vue-components'
+import { NeDropdown, NeTitle } from '@nethesis/vue-components'
 import {
   getAxiosErrorMessage,
   NeButton,
   NeSkeleton,
-  NeTitle,
   NeModal,
   NeEmptyState,
   NeInlineNotification

--- a/src/components/standalone/ssh/SshConfig.vue
+++ b/src/components/standalone/ssh/SshConfig.vue
@@ -6,10 +6,10 @@
 <script lang="ts" setup>
 import type { Ref } from 'vue'
 import { onMounted, ref } from 'vue'
+import { NeCheckbox } from '@nethesis/vue-components'
 import {
   getAxiosErrorMessage,
   NeButton,
-  NeCheckbox,
   NeInlineNotification,
   NeSkeleton,
   NeTextInput

--- a/src/components/standalone/subscription/UnitSubscription.vue
+++ b/src/components/standalone/subscription/UnitSubscription.vue
@@ -6,11 +6,10 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import FormLayout from '@/components/standalone/FormLayout.vue'
-import { NeBadge } from '@nethesis/vue-components'
+import { NeBadge, NeTitle } from '@nethesis/vue-components'
 import {
   NeButton,
   NeTextInput,
-  NeTitle,
   NeInlineNotification,
   NeSkeleton,
   focusElement,

--- a/src/components/standalone/system_settings/TimeSynchronization.vue
+++ b/src/components/standalone/system_settings/TimeSynchronization.vue
@@ -7,10 +7,9 @@
 import { getUciConfig, ubusCall } from '@/lib/standalone/ubus'
 import { validateHost, validateRequired } from '@/lib/validation'
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
-import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
+import { NeCombobox, type NeComboboxOption, NeCheckbox } from '@nethesis/vue-components'
 import {
   NeButton,
-  NeCheckbox,
   NeToggle,
   NeSkeleton,
   NeInlineNotification,

--- a/src/components/standalone/update/SystemUpdateInProgressModal.vue
+++ b/src/components/standalone/update/SystemUpdateInProgressModal.vue
@@ -4,7 +4,8 @@
 -->
 
 <script setup lang="ts">
-import { NeProgressBar, NeModal } from '@nethserver/vue-tailwind-lib'
+import { NeProgressBar } from '@nethesis/vue-components'
+import { NeModal } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
 import { watch } from 'vue'
 import { useTimer } from '@/composables/useTimer'

--- a/src/components/standalone/update/UpdatePackagesModal.vue
+++ b/src/components/standalone/update/UpdatePackagesModal.vue
@@ -7,12 +7,8 @@
 import { useTimer } from '@/composables/useTimer'
 import { ubusCall } from '@/lib/standalone/ubus'
 import type { PackageUpdate } from '@/views/standalone/system/UpdateView.vue'
-import {
-  getAxiosErrorMessage,
-  NeModal,
-  NeInlineNotification,
-  NeProgressBar
-} from '@nethserver/vue-tailwind-lib'
+import { NeProgressBar } from '@nethesis/vue-components'
+import { getAxiosErrorMessage, NeModal, NeInlineNotification } from '@nethserver/vue-tailwind-lib'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/src/components/standalone/update/UploadImageDrawer.vue
+++ b/src/components/standalone/update/UploadImageDrawer.vue
@@ -5,14 +5,14 @@
 
 <script setup lang="ts">
 import { validateFile } from '@/lib/validation'
-import { getAxiosErrorMessage } from '@nethserver/vue-tailwind-lib'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { NeFileInput } from '@nethesis/vue-components'
 import {
   NeSideDrawer,
   NeInlineNotification,
-  NeFileInput,
-  NeButton
+  NeButton,
+  getAxiosErrorMessage
 } from '@nethserver/vue-tailwind-lib'
 import { ubusCall } from '@/lib/standalone/ubus'
 import { uploadFile } from '@/lib/standalone/fileUpload'

--- a/src/components/standalone/users_database/UsersDatabaseManager.vue
+++ b/src/components/standalone/users_database/UsersDatabaseManager.vue
@@ -6,9 +6,8 @@
 <script setup lang="ts">
 import { ubusCall } from '@/lib/standalone/ubus'
 import type { UserDatabase } from '@/views/standalone/vpn/UsersDatabaseView.vue'
-import { NeDropdown } from '@nethesis/vue-components'
+import { NeDropdown, NeTitle } from '@nethesis/vue-components'
 import {
-  NeTitle,
   NeButton,
   NeEmptyState,
   NeSkeleton,

--- a/src/views/standalone/AccountView.vue
+++ b/src/views/standalone/AccountView.vue
@@ -4,8 +4,8 @@
 -->
 
 <script lang="ts" setup>
-import { NeCombobox } from '@nethesis/vue-components'
-import { NeTitle, savePreference } from '@nethserver/vue-tailwind-lib'
+import { NeCombobox, NeTitle } from '@nethesis/vue-components'
+import { savePreference } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
 import ChangePassword from '@/components/standalone/account/ChangePassword.vue'
 import { useLoginStore } from '@/stores/standalone/standaloneLogin'

--- a/src/views/standalone/LogsView.vue
+++ b/src/views/standalone/LogsView.vue
@@ -1,10 +1,9 @@
 <script lang="ts" setup>
-import { NeCombobox, type NeComboboxOption } from '@nethesis/vue-components'
+import { NeCombobox, type NeComboboxOption, NeTitle } from '@nethesis/vue-components'
 import {
   getAxiosErrorMessage,
   NeInlineNotification,
   NeTextInput,
-  NeTitle,
   NeToggle,
   NeTooltip
 } from '@nethserver/vue-tailwind-lib'

--- a/src/views/standalone/ReportView.vue
+++ b/src/views/standalone/ReportView.vue
@@ -4,7 +4,8 @@
 -->
 
 <script lang="ts" setup>
-import { NeTabs, NeTitle } from '@nethserver/vue-tailwind-lib'
+import { NeTitle } from '@nethesis/vue-components'
+import { NeTabs } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
 import { onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'

--- a/src/views/standalone/StandaloneDashboardView.vue
+++ b/src/views/standalone/StandaloneDashboardView.vue
@@ -4,8 +4,7 @@
 -->
 
 <script setup lang="ts">
-import { NeCard, NeLink } from '@nethesis/vue-components'
-import { NeTitle } from '@nethserver/vue-tailwind-lib'
+import { NeCard, NeLink, NeTitle } from '@nethesis/vue-components'
 import { useI18n } from 'vue-i18n'
 import RealTimeTrafficCard from '@/components/standalone/dashboard/RealTimeTrafficCard.vue'
 import SystemInfoCard from '@/components/standalone/dashboard/SystemInfoCard.vue'

--- a/src/views/standalone/firewall/FirewallRulesView.vue
+++ b/src/views/standalone/firewall/FirewallRulesView.vue
@@ -4,7 +4,8 @@
 -->
 
 <script setup lang="ts">
-import { NeTitle, NeTabs } from '@nethserver/vue-tailwind-lib'
+import { NeTitle } from '@nethesis/vue-components'
+import { NeTabs } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
 import { useTabs } from '@/composables/useTabs'
 import FirewallRulesContent from '@/components/standalone/firewall/rules/FirewallRulesContent.vue'

--- a/src/views/standalone/firewall/PortForward.vue
+++ b/src/views/standalone/firewall/PortForward.vue
@@ -5,8 +5,8 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { NeTitle } from '@nethesis/vue-components'
 import {
-  NeTitle,
   getAxiosErrorMessage,
   NeButton,
   NeTextInput,

--- a/src/views/standalone/firewall/ZonesAndPolicies.vue
+++ b/src/views/standalone/firewall/ZonesAndPolicies.vue
@@ -4,8 +4,8 @@
 -->
 
 <script lang="ts" setup>
-import { NeBadge, NeDropdown } from '@nethesis/vue-components'
-import { NeButton, NeInlineNotification, NeTitle } from '@nethserver/vue-tailwind-lib'
+import { NeBadge, NeDropdown, NeTitle } from '@nethesis/vue-components'
+import { NeButton, NeInlineNotification } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
 import NeTable from '@/components/standalone/NeTable.vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'

--- a/src/views/standalone/network/DnsDhcpView.vue
+++ b/src/views/standalone/network/DnsDhcpView.vue
@@ -4,7 +4,8 @@
 -->
 
 <script setup lang="ts">
-import { NeTitle, NeTabs } from '@nethserver/vue-tailwind-lib'
+import { NeTitle } from '@nethesis/vue-components'
+import { NeTabs } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
 import DhcpManager from '@/components/standalone/dns_dhcp/DhcpManager.vue'
 import StaticLeases from '@/components/standalone/dns_dhcp/StaticLeases.vue'

--- a/src/views/standalone/network/HotspotView.vue
+++ b/src/views/standalone/network/HotspotView.vue
@@ -4,7 +4,8 @@
 -->
 
 <script lang="ts" setup>
-import { NeTabs, NeTitle } from '@nethserver/vue-tailwind-lib'
+import { NeTitle } from '@nethesis/vue-components'
+import { NeTabs } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
 import { onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'

--- a/src/views/standalone/network/InterfacesAndDevicesView.vue
+++ b/src/views/standalone/network/InterfacesAndDevicesView.vue
@@ -5,9 +5,8 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { NeBadge, NeDropdown } from '@nethesis/vue-components'
+import { NeBadge, NeDropdown, NeTitle } from '@nethesis/vue-components'
 import {
-  NeTitle,
   NeButton,
   NeInlineNotification,
   getAxiosErrorMessage,

--- a/src/views/standalone/network/MultiWanView.vue
+++ b/src/views/standalone/network/MultiWanView.vue
@@ -4,7 +4,8 @@
 -->
 
 <script lang="ts" setup>
-import { NeTabs, NeTitle } from '@nethserver/vue-tailwind-lib'
+import { NeTitle } from '@nethesis/vue-components'
+import { NeTabs } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
 import MultiWanGeneralSettings from '@/components/standalone/multi-wan/MultiWanGeneralSettings.vue'
 import MultiWanManager from '@/components/standalone/multi-wan/MultiWanManager.vue'

--- a/src/views/standalone/network/QoSView.vue
+++ b/src/views/standalone/network/QoSView.vue
@@ -5,8 +5,8 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { NeTitle } from '@nethesis/vue-components'
 import {
-  NeTitle,
   NeButton,
   NeInlineNotification,
   NeSkeleton,

--- a/src/views/standalone/network/ReverseProxyView.vue
+++ b/src/views/standalone/network/ReverseProxyView.vue
@@ -5,8 +5,8 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { NeTitle } from '@nethesis/vue-components'
 import {
-  NeTitle,
   getAxiosErrorMessage,
   NeButton,
   NeEmptyState,

--- a/src/views/standalone/network/RoutesView.vue
+++ b/src/views/standalone/network/RoutesView.vue
@@ -4,7 +4,8 @@
 -->
 
 <script lang="ts" setup>
-import { NeTabs, NeTitle } from '@nethserver/vue-tailwind-lib'
+import { NeTitle } from '@nethesis/vue-components'
+import { NeTabs } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
 import RoutesContent from '@/components/standalone/routes/RoutesContent.vue'
 import { useTabs } from '@/composables/useTabs'

--- a/src/views/standalone/security/DpiFilterView.vue
+++ b/src/views/standalone/security/DpiFilterView.vue
@@ -4,7 +4,8 @@
 -->
 
 <script setup lang="ts">
-import { NeTitle, NeTabs } from '@nethserver/vue-tailwind-lib'
+import { NeTitle } from '@nethesis/vue-components'
+import { NeTabs } from '@nethserver/vue-tailwind-lib'
 import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'

--- a/src/views/standalone/security/FlashStartView.vue
+++ b/src/views/standalone/security/FlashStartView.vue
@@ -4,7 +4,7 @@
 -->
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { NeTitle } from '@nethserver/vue-tailwind-lib'
+import { NeTitle } from '@nethesis/vue-components'
 const { t } = useI18n()
 import FlashstartContent from '@/components/standalone/security/FlashstartContent.vue'
 </script>

--- a/src/views/standalone/system/BackupAndRestoreView.vue
+++ b/src/views/standalone/system/BackupAndRestoreView.vue
@@ -6,7 +6,8 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { useTabs } from '@/composables/useTabs'
-import { NeTitle, NeTabs } from '@nethserver/vue-tailwind-lib'
+import { NeTitle } from '@nethesis/vue-components'
+import { NeTabs } from '@nethserver/vue-tailwind-lib'
 import BackupContent from '@/components/standalone/backup_and_restore/BackupContent.vue'
 import RestoreContent from '@/components/standalone/backup_and_restore/RestoreContent.vue'
 import MigrationContent from '@/components/standalone/backup_and_restore/MigrationContent.vue'

--- a/src/views/standalone/system/CertificatesView.vue
+++ b/src/views/standalone/system/CertificatesView.vue
@@ -5,8 +5,8 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { NeTitle } from '@nethesis/vue-components'
 import {
-  NeTitle,
   NeButton,
   getAxiosErrorMessage,
   NeSkeleton,

--- a/src/views/standalone/system/FactoryResetView.vue
+++ b/src/views/standalone/system/FactoryResetView.vue
@@ -4,7 +4,7 @@
 -->
 
 <script setup lang="ts">
-import { NeTitle } from '@nethserver/vue-tailwind-lib'
+import { NeTitle } from '@nethesis/vue-components'
 import { useI18n } from 'vue-i18n'
 import FactoryResetContent from '@/components/standalone/factory_reset/FactoryResetContent.vue'
 

--- a/src/views/standalone/system/RebootAndShutdownView.vue
+++ b/src/views/standalone/system/RebootAndShutdownView.vue
@@ -7,10 +7,9 @@
 import { useTimer } from '@/composables/useTimer'
 import { ubusCall } from '@/lib/standalone/ubus'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { NeProgressBar } from '@nethesis/vue-components'
+import { NeProgressBar, NeTitle } from '@nethesis/vue-components'
 import {
   NeButton,
-  NeTitle,
   NeModal,
   NeInlineNotification,
   getAxiosErrorMessage,

--- a/src/views/standalone/system/RebootAndShutdownView.vue
+++ b/src/views/standalone/system/RebootAndShutdownView.vue
@@ -7,12 +7,12 @@
 import { useTimer } from '@/composables/useTimer'
 import { ubusCall } from '@/lib/standalone/ubus'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { NeProgressBar } from '@nethesis/vue-components'
 import {
   NeButton,
   NeTitle,
   NeModal,
   NeInlineNotification,
-  NeProgressBar,
   getAxiosErrorMessage,
   NeSkeleton
 } from '@nethserver/vue-tailwind-lib'

--- a/src/views/standalone/system/StorageView.vue
+++ b/src/views/standalone/system/StorageView.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { ubusCall } from '@/lib/standalone/ubus'
+import { NeTitle } from '@nethesis/vue-components'
 import {
-  NeTitle,
   getAxiosErrorMessage,
   NeInlineNotification,
   NeRadioSelection,

--- a/src/views/standalone/system/SystemSettingsView.vue
+++ b/src/views/standalone/system/SystemSettingsView.vue
@@ -4,7 +4,8 @@
 -->
 
 <script setup lang="ts">
-import { NeTitle, NeTabs } from '@nethserver/vue-tailwind-lib'
+import { NeTitle } from '@nethesis/vue-components'
+import { NeTabs } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
 import GeneralSettings from '@/components/standalone/system_settings/GeneralSettings.vue'
 import TimeSynchronization from '@/components/standalone/system_settings/TimeSynchronization.vue'

--- a/src/views/standalone/system/UpdateView.vue
+++ b/src/views/standalone/system/UpdateView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import { NeTitle } from '@nethesis/vue-components'
 import {
-  NeTitle,
   NeButton,
   NeInlineNotification,
   NeModal,

--- a/src/views/standalone/vpn/IPsecTunnelView.vue
+++ b/src/views/standalone/vpn/IPsecTunnelView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { NeTitle } from '@nethesis/vue-components'
 import {
-  NeTitle,
   NeButton,
   NeEmptyState,
   NeInlineNotification,

--- a/src/views/standalone/vpn/OpenvpnRoadWarriorView.vue
+++ b/src/views/standalone/vpn/OpenvpnRoadWarriorView.vue
@@ -5,8 +5,8 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { NeTitle } from '@nethesis/vue-components'
 import {
-  NeTitle,
   NeEmptyState,
   NeButton,
   getAxiosErrorMessage,

--- a/src/views/standalone/vpn/OpenvpnTunnelView.vue
+++ b/src/views/standalone/vpn/OpenvpnTunnelView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useTabs } from '@/composables/useTabs'
-import { NeTabs, NeTitle } from '@nethserver/vue-tailwind-lib'
+import { NeTitle } from '@nethesis/vue-components'
+import { NeTabs } from '@nethserver/vue-tailwind-lib'
 import { useI18n } from 'vue-i18n'
 import TunnelManager from '@/components/standalone/openvpn_tunnel/TunnelManager.vue'
 

--- a/src/views/standalone/vpn/UsersDatabaseView.vue
+++ b/src/views/standalone/vpn/UsersDatabaseView.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useTabs } from '@/composables/useTabs'
 import { ubusCall } from '@/lib/standalone/ubus'
+import { NeTitle } from '@nethesis/vue-components'
 import {
-  NeTitle,
   NeTabs,
   NeButton,
   getAxiosErrorMessage,


### PR DESCRIPTION
Import the following components from `vue-components` instead of `vue-tailwind-lib`:
- NeCheckbox
- NeExpandable
- NeProgressBar
- NeFileInput
- NeTitle

NeInlineNotification and NeSideDrawer will be migrated in a different PR

See:
- https://github.com/NethServer/vue-tailwind-lib/pull/30