### PR TITLE
QoS: fix selected interface not showing when editing QoS interface

### DIFF
--- a/src/components/standalone/qos/CreateOrEditQoSInterfaceDrawer.vue
+++ b/src/components/standalone/qos/CreateOrEditQoSInterfaceDrawer.vue
@@ -61,7 +61,7 @@ async function fetchOptions() {
         (x: any) =>
           x.iface &&
           x.iface['.type'] === 'interface' &&
-          !props.configuredInterfaces.includes(x.iface['.name'])
+          (props.itemToEdit || !props.configuredInterfaces.includes(x.iface['.name']))
       )
       .map((x: any) => ({
         id: x.iface['.name'],


### PR DESCRIPTION
This PR fixes the selected interface not showing when editing QoS interface. It was caused by the additional filter introduced with one of the latest PRs to avoid displaying already selected interfaces. Now this filter is only applied when creating a QoS interface rather than editing it.

Card: https://trello.com/c/crPiIiGg/323-qos-bad-interface-selected