### PR TITLE
DHCP: include option number in DHCP options when editing interface

### DIFF
--- a/src/components/standalone/dns_dhcp/EditDhcpInterfaceDrawer.vue
+++ b/src/components/standalone/dns_dhcp/EditDhcpInterfaceDrawer.vue
@@ -110,7 +110,7 @@ async function loadDhcpOptions() {
     availableDhcpOptions.value = Object.keys(dhcpOptionsResponse).map((dhcpOptionKey) => {
       return {
         id: dhcpOptionKey,
-        label: dhcpOptionKey
+        label: `${dhcpOptionsResponse[dhcpOptionKey]}: ${dhcpOptionKey}`
       }
     })
     loading.value = false


### PR DESCRIPTION
- Include option number in DHCP options when editing DHCP interface

Card: https://trello.com/c/2ei2yD64/326-dhcp-allow-option-number-in-advanced-section