### PR TITLE
Firewall rules: allow showing more than one address on source and destination address fields

### DIFF
--- a/src/components/standalone/firewall/rules/SourceOrDestinationRuleColumn.vue
+++ b/src/components/standalone/firewall/rules/SourceOrDestinationRuleColumn.vue
@@ -58,53 +58,56 @@ const zone = computed(() => {
     </template>
     <template v-else-if="addresses.length">
       <!-- show addresses -->
-      <template v-if="addresses[0].label">
-        <NeTooltip>
-          <template #trigger>
-            <span class="text-primary-700 dark:text-primary-500">
-              {{ addresses[0].label }}
+      <template v-for="(addr, i) in addresses.slice(0, 2)" :key="addr.value">
+        <p>
+          <template v-if="addr.label">
+            <NeTooltip>
+              <template #trigger>
+                <span class="text-primary-700 dark:text-primary-500">
+                  {{ addr.label }}
+                </span>
+              </template>
+              <template #content>
+                {{ addr.value }}
+              </template>
+            </NeTooltip>
+          </template>
+          <template v-else>
+            <span :class="{ 'opacity-50': !enabled }">
+              {{ addr.value }}
             </span>
           </template>
-          <template #content>
-            {{ addresses[0].value }}
+          <template v-if="i == 1 && addresses.length > 2">
+            <!-- show +n others -->
+            <NeTooltip>
+              <template #trigger>
+                <span class="ml-2 text-primary-700 dark:text-primary-500">
+                  {{
+                    t(
+                      'common.plus_num_others',
+                      {
+                        num: addresses.length - 2
+                      },
+                      addresses.length - 2
+                    )
+                  }}
+                </span>
+              </template>
+              <template #content>
+                <ul class="list-inside list-disc">
+                  <li v-for="(addr, i) in addresses.slice(2)" :key="i">
+                    <template v-if="addr.label">
+                      {{ `${addr.label} (${addr.value})` }}
+                    </template>
+                    <template v-else>
+                      {{ addr.value }}
+                    </template>
+                  </li>
+                </ul>
+              </template>
+            </NeTooltip>
           </template>
-        </NeTooltip>
-      </template>
-      <template v-else>
-        <span :class="{ 'opacity-50': !enabled }">
-          {{ addresses[0].value }}
-        </span>
-      </template>
-
-      <template v-if="addresses.length > 1">
-        <!-- show +n others -->
-        <NeTooltip>
-          <template #trigger>
-            <span class="ml-2 text-primary-700 dark:text-primary-500">
-              {{
-                t(
-                  'common.plus_num_others',
-                  {
-                    num: addresses.length - 1
-                  },
-                  addresses.length - 1
-                )
-              }}
-            </span>
-          </template>
-          <template #content>
-            <ul class="list-inside list-disc">
-              <li v-for="(addr, i) in addresses.slice(1)" :key="i">
-                <template v-if="addr.label">
-                  {{ `${addr.label} (${addr.value})` }}
-                </template>
-                <template v-else>
-                  {{ addr.value }}
-                </template>
-              </li>
-            </ul>
-          </template>
-        </NeTooltip>
+        </p>
       </template>
     </template>
     <template v-else>


### PR DESCRIPTION
- Allow showing more than one address on source and destination address fields, showing at most two values

Here's an image showing how the table looks after these changes:
![image](https://github.com/NethServer/nethsecurity-ui/assets/9089193/eea15006-6d9d-4f56-99ed-3f09cf9a32af)

Card: https://trello.com/c/NjNgR4na/329-firewall-rules-multiple-address-page-organization