### PR TITLE
Interfaces: display packets in a more readable format

### DIFF
--- a/src/views/standalone/network/InterfacesAndDevicesView.vue
+++ b/src/views/standalone/network/InterfacesAndDevicesView.vue
@@ -790,10 +790,7 @@ function formatPackets(packets: number) {
                           <span class="font-medium">TX: </span>
                           <span>{{ getTxBytes(device) || '-' }}</span>
                           <span v-if="device.stats?.tx_packets">
-                            ({{
-                              device.stats.tx_packets ? formatPackets(device.stats.tx_packets) : '-'
-                            }}
-                            pkts)</span
+                            ({{ formatPackets(device.stats.tx_packets) }} pkts)</span
                           >
                         </div>
                       </div>

--- a/src/views/standalone/network/InterfacesAndDevicesView.vue
+++ b/src/views/standalone/network/InterfacesAndDevicesView.vue
@@ -518,6 +518,14 @@ function isDeviceConfigurable(deviceOrIface: DeviceOrIface) {
     return true
   }
 }
+
+function formatPackets(packets: number) {
+  if (packets >= 1e6) {
+    return (packets / 1e6).toLocaleString(undefined, { maximumFractionDigits: 2 }) + 'M'
+  }
+
+  return packets.toLocaleString()
+}
 </script>
 
 <template>
@@ -775,14 +783,17 @@ function isDeviceConfigurable(deviceOrIface: DeviceOrIface) {
                           <span class="font-medium">RX: </span>
                           <span>{{ getRxBytes(device) || '-' }}</span>
                           <span v-if="device.stats?.rx_packets">
-                            ({{ device.stats.rx_packets }} pkts)</span
+                            ({{ formatPackets(device.stats.rx_packets) }} pkts)</span
                           >
                         </div>
                         <div v-if="getTxBytes(device)">
                           <span class="font-medium">TX: </span>
                           <span>{{ getTxBytes(device) || '-' }}</span>
                           <span v-if="device.stats?.tx_packets">
-                            ({{ device.stats.tx_packets || '-' }} pkts)</span
+                            ({{
+                              device.stats.tx_packets ? formatPackets(device.stats.tx_packets) : '-'
+                            }}
+                            pkts)</span
                           >
                         </div>
                       </div>


### PR DESCRIPTION
- Display packets in a more readable format in the Devices and interfaces page: 
  - Value is formatted depending on the browser's locale
  - Use M unit if packets are above 1 million

Card: https://trello.com/c/dNrGfN8n/324-interfaces-humanify-packet-count