### PR TITLE
fix: show firewall/nat targets in uppercase

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -1068,11 +1068,6 @@
     "zones_and_policies": {
       "title": "Zones & Policies",
       "description": "The firewall creates zones over your network interfaces to control network traffic flow.",
-      "traffic_policy": {
-        "accept": "Accept",
-        "reject": "Reject",
-        "drop": "Drop"
-      },
       "zone": "Zone",
       "allow_forwards_to": "Allow forwards to",
       "allow_forwards_from": "Allow forwards from",
@@ -1171,9 +1166,6 @@
       "destination_zone": "Destination zone",
       "destination_zone_tooltip": "Specifies the traffic destination zone, which must be distinct from the source zone.",
       "choose_action": "Choose action",
-      "drop": "Drop",
-      "accept": "Accept",
-      "reject": "Reject",
       "custom_service": "Custom service",
       "protocols": "Protocols",
       "ports": "Ports",
@@ -1675,11 +1667,8 @@
       "destination_address": "Destination address",
       "destination_address_tooltip": "Match forwarded traffic directed at this IPv4 address or CIDR",
       "action": "Action",
-      "action_snat": "SNAT",
       "action_snat_description": "Rewrite to specific source IP or port",
-      "action_masquerade": "Masquerade",
       "action_masquerade_description": "Automatically rewrite to outbound interface IP",
-      "action_accept": "Accept (no NAT)",
       "action_accept_description": "Disable address rewriting",
       "rewrite_ip_address": "Rewrite IP address",
       "rewrite_ip": "Rewrite IP",

--- a/public/i18n/it/translation.json
+++ b/public/i18n/it/translation.json
@@ -662,11 +662,6 @@
       "select_policy": "Seleziona la policy"
     },
     "zones_and_policies": {
-      "traffic_policy": {
-        "drop": "Scarta (drop)",
-        "reject": "Rifiuta (reject)",
-        "accept": "Accetta"
-      },
       "allow_forwards_to": "Consenti forward a",
       "logging": "Logging",
       "traffic_to_same_zone": "Traffico verso la stessa zona",

--- a/src/components/standalone/firewall/CreateOrEditZoneDrawer.vue
+++ b/src/components/standalone/firewall/CreateOrEditZoneDrawer.vue
@@ -125,15 +125,15 @@ const forwardPlaceholder = computed((): string => {
 const trafficOptions = [
   {
     id: TrafficPolicy.DROP,
-    label: t('standalone.zones_and_policies.traffic_policy.' + TrafficPolicy.DROP)
+    label: 'DROP'
   },
   {
     id: TrafficPolicy.REJECT,
-    label: t('standalone.zones_and_policies.traffic_policy.' + TrafficPolicy.REJECT)
+    label: 'REJECT'
   },
   {
     id: TrafficPolicy.ACCEPT,
-    label: t('standalone.zones_and_policies.traffic_policy.' + TrafficPolicy.ACCEPT)
+    label: 'ACCEPT'
   }
 ]
 

--- a/src/components/standalone/firewall/nat/CreateOrEditNatRuleDrawer.vue
+++ b/src/components/standalone/firewall/nat/CreateOrEditNatRuleDrawer.vue
@@ -76,17 +76,15 @@ let error = ref({
 const actionOptions = ref([
   {
     id: 'SNAT',
-    label: `${t('standalone.nat.action_snat')}: ${t('standalone.nat.action_snat_description')}`
+    label: `SNAT: ${t('standalone.nat.action_snat_description')}`
   },
   {
     id: 'MASQUERADE',
-    label: `${t('standalone.nat.action_masquerade')}: ${t(
-      'standalone.nat.action_masquerade_description'
-    )}`
+    label: `MASQUERADE: ${t('standalone.nat.action_masquerade_description')}`
   },
   {
     id: 'ACCEPT',
-    label: `${t('standalone.nat.action_accept')}: ${t('standalone.nat.action_accept_description')}`
+    label: `ACCEPT (no NAT): ${t('standalone.nat.action_accept_description')}`
   }
 ])
 

--- a/src/components/standalone/firewall/nat/NatRulesTable.vue
+++ b/src/components/standalone/firewall/nat/NatRulesTable.vue
@@ -85,7 +85,7 @@ function getDropdownItems(rule: NatRule) {
         />
       </template>
       <template #target="{ item }: { item: NatRule }">
-        {{ t(`standalone.nat.action_${item.target.toLowerCase()}`) }}
+        {{ item.target }}
       </template>
       <template #snat_ip="{ item }: { item: NatRule }">
         <span v-if="item.snat_ip">{{ item.snat_ip }}</span>

--- a/src/components/standalone/firewall/rules/CreateOrEditFirewallRuleDrawer.vue
+++ b/src/components/standalone/firewall/rules/CreateOrEditFirewallRuleDrawer.vue
@@ -92,15 +92,15 @@ const errorBag = ref(new MessageBag())
 const actionOptions = ref([
   {
     id: 'DROP',
-    label: t('standalone.firewall_rules.drop')
+    label: 'DROP'
   },
   {
     id: 'REJECT',
-    label: t('standalone.firewall_rules.reject')
+    label: 'REJECT'
   },
   {
     id: 'ACCEPT',
-    label: t('standalone.firewall_rules.accept')
+    label: 'ACCEPT'
   }
 ])
 

--- a/src/components/standalone/firewall/rules/FirewallRulesTable.vue
+++ b/src/components/standalone/firewall/rules/FirewallRulesTable.vue
@@ -366,7 +366,7 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                       :icon="['fas', getRuleActionIcon(rule.target)]"
                       :class="getRuleActionColor(rule)"
                     />
-                    {{ t(`standalone.firewall_rules.${rule.target.toLowerCase()}`) }}
+                    {{ rule.target }}
                   </span>
                 </td>
                 <td>

--- a/src/views/standalone/firewall/ZonesAndPolicies.vue
+++ b/src/views/standalone/firewall/ZonesAndPolicies.vue
@@ -159,24 +159,24 @@ function editZone(zone: Zone) {
           >
           <template v-else-if="getTrafficToWan(item, firewallConfig.forwardings)">
             <FontAwesomeIcon :icon="['fas', 'arrow-right']" />
-            <p>{{ t('standalone.zones_and_policies.traffic_policy.accept') }}</p>
+            <p>ACCEPT</p>
           </template>
           <template v-else>
             <FontAwesomeIcon :icon="['fas', 'ban']" />
-            <p>{{ t('standalone.zones_and_policies.traffic_policy.reject') }}</p>
+            <p>REJECT</p>
           </template>
         </div>
       </template>
       <template #input="{ item }: { item: Zone }">
         <div class="flex items-center gap-x-2">
           <FontAwesomeIcon :icon="['fas', trafficIcon(item.input)]" />
-          {{ t(`standalone.zones_and_policies.traffic_policy.${item.input}`) }}
+          {{ item.input.toUpperCase() }}
         </div>
       </template>
       <template #forward="{ item }: { item: Zone }">
         <div class="flex items-center gap-x-2">
           <FontAwesomeIcon :icon="['fas', trafficIcon(item.forward)]" />
-          {{ t(`standalone.zones_and_policies.traffic_policy.${item.forward}`) }}
+          {{ item.forward.toUpperCase() }}
         </div>
       </template>
       <template #interfaces="{ item }: { item: Zone }">


### PR DESCRIPTION
Don't translate firewall/NAT targets (DROP, REJECT, ACCEPT, SNAT, MASQUERADE) and show them in uppercase on the UI