### PR TITLE
fix: validation of IPsec remote IP address

### DIFF
--- a/src/components/standalone/ipsec_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/ipsec_tunnel/CreateOrEditTunnelDrawer.vue
@@ -6,8 +6,8 @@
 <script setup lang="ts">
 import {
   MessageBag,
+  validateHost,
   validateIp4Cidr,
-  validateIpAddress,
   validatePositiveInteger,
   validateRequired,
   validateRequiredOption,
@@ -310,7 +310,7 @@ function validateFormByStep(step: number): boolean {
       [[validateRequired(name.value)], 'name'],
       [[validateRequired(wanIpAddress.value)], 'wanIpAddress'],
       [
-        [validateRequired(remoteIpAddress.value), validateIpAddress(remoteIpAddress.value)],
+        [validateRequired(remoteIpAddress.value), validateHost(remoteIpAddress.value)],
         'remoteIpAddress'
       ],
       [


### PR DESCRIPTION
Remote IP address field of IPsec tunnel now accept:
- an IP addresses
- a hostname
- "any"