### PR TITLE
Reverse proxy: disable type and domain fields when editing entry

### DIFF
--- a/src/components/standalone/reverse_proxy/CreateOrEditProxyDrawer.vue
+++ b/src/components/standalone/reverse_proxy/CreateOrEditProxyDrawer.vue
@@ -283,6 +283,7 @@ watch(
         :label="t('standalone.reverse_proxy.type')"
         :options="typeOptions"
         v-model="type"
+        :disabled="Boolean(itemToEdit)"
       />
       <NeTextInput
         v-if="type === 'path'"
@@ -302,6 +303,7 @@ watch(
           v-model="domain"
           :label="t('standalone.reverse_proxy.domain')"
           :invalid-message="t(validationErrorBag.getFirstI18nKeyFor('domain'))"
+          :disabled="Boolean(itemToEdit)"
           ><template #tooltip>
             <NeTooltip>
               <template #content>


### PR DESCRIPTION
- Disable type and domain fields on edit

Card: https://trello.com/c/g1s50b0E/357-proxy-pass-unable-to-modify-existing-domain