### PR TITLE
Firewall: use correct opacity in disabled source and destination fields in input and output rules

### DIFF
--- a/src/components/standalone/firewall/rules/SourceOrDestinationRuleColumn.vue
+++ b/src/components/standalone/firewall/rules/SourceOrDestinationRuleColumn.vue
@@ -51,10 +51,18 @@ const zone = computed(() => {
 <template>
   <div>
     <template v-if="rulesType === 'input' && props.columnType === 'destination'">
-      <NeBadge :text="t('standalone.firewall_rules.firewall')" kind="tertiary" />
+      <NeBadge
+        :class="{ 'opacity-50': !enabled }"
+        :text="t('standalone.firewall_rules.firewall')"
+        kind="tertiary"
+      />
     </template>
     <template v-else-if="rulesType === 'output' && props.columnType === 'source'">
-      <NeBadge :text="t('standalone.firewall_rules.firewall')" kind="tertiary" />
+      <NeBadge
+        :class="{ 'opacity-50': !enabled }"
+        :text="t('standalone.firewall_rules.firewall')"
+        kind="tertiary"
+      />
     </template>
     <template v-else-if="addresses.length">
       <!-- show addresses -->


### PR DESCRIPTION
- Fix issue where the source in the output rules or the destination in the input rules would not have the correct opacity if disabled

Card: https://trello.com/c/sL9NvFmw/355-firewall-disabled-rule-label-color