### PR TITLE
 fix: retrieving zones without aliases in mwan and firewall

### DIFF
--- a/src/components/standalone/multi-wan/PolicyCreator.vue
+++ b/src/components/standalone/multi-wan/PolicyCreator.vue
@@ -49,7 +49,7 @@ const error = ref<Error>()
 const labelElement = ref<HTMLInputElement | null>(null)
 
 const availableGateways = computed((): Array<NeComboboxOption> => {
-  return firewall.zones
+  return firewall.zonesWithoutAliases
     .filter((zone: Zone) => zone.configName == 'ns_wan')
     .map((zone: Zone) => zone.interfaces)
     .flat()

--- a/src/components/standalone/multi-wan/PolicyEditor.vue
+++ b/src/components/standalone/multi-wan/PolicyEditor.vue
@@ -49,7 +49,7 @@ const loading = ref(false)
 const error = ref<Error>()
 
 const availableGateways = computed((): Array<NeComboboxOption> => {
-  return firewall.zones
+  return firewall.zonesWithoutAliases
     .filter((zone: Zone) => zone.configName == 'ns_wan')
     .map((zone: Zone) => zone.interfaces)
     .flat()

--- a/src/stores/standalone/firewall.ts
+++ b/src/stores/standalone/firewall.ts
@@ -258,6 +258,7 @@ export const useFirewallStore = defineStore('firewall', () => {
   const error = ref<Error>()
   const zones = ref<Array<Zone>>([])
   const forwardings = ref<Array<Forwarding>>([])
+  const zonesWithoutAliases = ref<Array<Zone>>([])
   const loading = ref(true)
 
   function fetch() {
@@ -275,11 +276,18 @@ export const useFirewallStore = defineStore('firewall', () => {
             ([name, forwardingResponse]) => new Forwarding(name, forwardingResponse)
           )
         }
+      ),
+      ubusCall('ns.firewall', 'list_zones_no_aliases').then(
+        (response: AxiosResponse<BaseResponse<ZoneResponse>>) => {
+          zonesWithoutAliases.value = Object.entries(response.data)
+            .map(([name, zoneResponse]) => new Zone(name, zoneResponse))
+            .sort(zonesSorting)
+        }
       )
     ])
       .catch((exception: Error) => (error.value = exception))
       .then(() => (loading.value = false))
   }
 
-  return { loading, error, zones, forwardings, fetch }
+  return { loading, error, zones, forwardings, zonesWithoutAliases, fetch }
 })

--- a/src/views/standalone/firewall/ZonesAndPolicies.vue
+++ b/src/views/standalone/firewall/ZonesAndPolicies.vue
@@ -86,7 +86,7 @@ function editZone(zone: Zone) {
     />
     <NeTable
       v-else
-      :data="firewallConfig.zones"
+      :data="firewallConfig.zonesWithoutAliases"
       :headers="[
         {
           key: 'label',


### PR DESCRIPTION
Implementing changes coming from NethServer/nethsecurity#360

Card: https://trello.com/c/LFCTBvU7/351-aliases-among-interfaces
