### PR TITLE
feat: cleaning up gateways on policy

### DIFF
--- a/src/composables/usePolicyForm.ts
+++ b/src/composables/usePolicyForm.ts
@@ -83,7 +83,9 @@ export function usePolicyForm(policy: Ref<Policy | undefined>) {
   })
 
   watch(selection, (value) => {
+    // When the selection changes, we need to update the priorities and filter/merge the gateways
     if (value == PolicyOptions.BACKUP) {
+      // merge all gateways into a single priority
       priorities.value = priorities.value
         .map((priority) => priority.map((gateway) => [gateway]))
         .flat(1)
@@ -91,9 +93,23 @@ export function usePolicyForm(policy: Ref<Policy | undefined>) {
         priorities.value.push([new Gateway()])
       }
     } else if (value == PolicyOptions.BALANCE) {
+      // flatten all priorities in a single gateway per priority
       priorities.value = [priorities.value.flat(1)]
       for (let i = priorities.value[0].length; i < 2; i++) {
         priorities.value[0].push(new Gateway())
+      }
+    } else {
+      // filter out empty gateways
+      priorities.value.forEach((gateways, index) => {
+        priorities.value[index] = gateways.filter((gateway) => gateway.id != '')
+      })
+      // filter out empty priorities
+      priorities.value = priorities.value.filter(
+        (gateways) => gateways.filter((gateway) => gateway.id != '').length > 0
+      )
+      // add a new priority if none is defined
+      if (priorities.value.length == 0) {
+        priorities.value = [[new Gateway()]]
       }
     }
   })


### PR DESCRIPTION
Swap behaviour has been criticized due to "not deleting" the empty fields when moving to the "Custom" option, this will address the issue.

Updated behaviour:

[Screencast from 2024-03-08 15-27-04.webm](https://github.com/NethServer/nethsecurity-ui/assets/8052641/516fb4ab-4250-4524-913d-332d34844b0c)
