### PR TITLE
OpenVPN tunnel: fix validation error when editing p2p tunnel

### DIFF
--- a/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
@@ -460,9 +460,12 @@ function validate() {
   } else {
     // server form fields validation
     const localNetworksCidrValidation = localNetworks.value.map((x) => validateIp4Cidr(x.id))
+    const vpnNetworkValidator: [validationOutput[], string][] = [
+      [[validateRequired(vpnNetwork.value), validateIp4Cidr(vpnNetwork.value)], 'vpnNetwork']
+    ]
     const serverTunnelFieldsValidators: [validationOutput[], string][] = [
       [[validateRequired(port.value), validatePort(port.value)], 'port'],
-      [[validateRequired(vpnNetwork.value), validateIp4Cidr(vpnNetwork.value)], 'vpnNetwork'],
+      ...(topology.value !== 'p2p' ? vpnNetworkValidator : []),
       [
         [
           validateRequiredOption(localNetworks.value),


### PR DESCRIPTION
- Fix an issue where the user couldn't edit a previously added P2P tunnel. This was caused by the presence of a validation on the `vpnNetwork` field which was not present if the tunnel was a P2P one.

Card: https://trello.com/c/V2Q4MhYl/378-cant-edit-openvpn-p2p-tunnel-server