### PR TITLE
OpenVPN tunnel: use different default cipher when creating a P2P tunnel

### DIFF
--- a/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
@@ -594,6 +594,15 @@ watch(
 )
 
 watch(
+  () => [topology.value],
+  () => {
+    if (!props.itemToEdit) {
+      cipher.value = topology.value === 'p2p' ? 'AES-256-CBC' : 'AES-256-GCM'
+    }
+  }
+)
+
+watch(
   () => props.isShown,
   () => {
     if (props.isShown) {


### PR DESCRIPTION
- Use `AES-256-CBC` as the default cipher when creating a P2P tunnel. When switching the topology to subnet, the default value will remain the previous one (`AES-256-GCM`).