### PR TITLE
Backup, restore and migration: use new api flow to handle file uploads

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -307,7 +307,8 @@
     "cannot_disconnect_unit": "Cannot disconnect unit",
     "cannot_connect_unit": "Cannot connect unit",
     "cannot_restart_connection": "Cannot restart connection",
-    "cannot_retrieve_join_code": "Cannot retrieve join code"
+    "cannot_retrieve_join_code": "Cannot retrieve join code",
+    "cannot_upload_backup": "Cannot upload backup"
   },
   "ne_text_input": {
     "show_password": "Show password",

--- a/src/components/standalone/backup_and_restore/MigrationDrawer.vue
+++ b/src/components/standalone/backup_and_restore/MigrationDrawer.vue
@@ -248,7 +248,11 @@ watch(
 
 <template>
   <div>
-    <NeSideDrawer :is-shown="showMigrationDrawer" title="" @close="$emit('close')">
+    <NeSideDrawer
+      :is-shown="showMigrationDrawer"
+      :title="t('standalone.backup_and_restore.migration.drawer_title')"
+      @close="$emit('close')"
+    >
       <NeSkeleton v-if="loading" :lines="5" />
       <NeInlineNotification
         v-if="!loading && errorLoadDevices.notificationTitle"
@@ -262,8 +266,6 @@ watch(
         </template>
       </NeInlineNotification>
       <div v-if="!loading && !errorLoadDevices.notificationTitle" class="space-y-5">
-        <NeTitle>{{ t('standalone.backup_and_restore.migration.drawer_title') }}</NeTitle>
-        <hr />
         <NeSkeleton v-if="isUploadingMigrationFile" :lines="5" />
         <NeFileInput
           v-else

--- a/src/components/standalone/backup_and_restore/MigrationDrawer.vue
+++ b/src/components/standalone/backup_and_restore/MigrationDrawer.vue
@@ -11,7 +11,6 @@ import {
   NeCombobox,
   NeFileInput,
   NeProgressBar,
-  NeTitle,
   NeInlineNotification,
   NeButton,
   NeSideDrawer,

--- a/src/components/standalone/backup_and_restore/ModalDownloadBackup.vue
+++ b/src/components/standalone/backup_and_restore/ModalDownloadBackup.vue
@@ -9,6 +9,8 @@ import { useI18n } from 'vue-i18n'
 import { ubusCall } from '@/lib/standalone/ubus'
 import { NeInlineNotification } from '@nethesis/vue-components'
 import { getAxiosErrorMessage, NeModal } from '@nethserver/vue-tailwind-lib'
+import { downloadFile } from '@/lib/standalone/fileUpload'
+import { deleteFile } from '@/lib/standalone/fileUpload'
 
 const { t } = useI18n()
 const props = defineProps({
@@ -55,14 +57,19 @@ async function downloadBackup() {
 
     let res = await ubusCall('ns.backup', methodCall, payload)
     if (res?.data?.backup) {
+      const file = await downloadFile(res.data.backup)
+      const fileURL = URL.createObjectURL(file)
+
       let extension = '.tar.gz'
       if (props.isSetPassphrase) {
         extension += '.gpg'
       }
       let link = document.createElement('a')
-      link.href = `data:application/gzip;base64,${res.data.backup}`
+      link.href = fileURL
       link.download = 'backup' + extension
       link.click()
+
+      await deleteFile(res.data.backup)
 
       emit('close')
     }

--- a/src/components/standalone/backup_and_restore/RestoreContent.vue
+++ b/src/components/standalone/backup_and_restore/RestoreContent.vue
@@ -11,7 +11,6 @@ import {
   NeCombobox,
   NeFileInput,
   NeProgressBar,
-  NeTitle,
   NeInlineNotification,
   NeButton,
   NeTooltip,

--- a/src/components/standalone/backup_and_restore/RestoreContent.vue
+++ b/src/components/standalone/backup_and_restore/RestoreContent.vue
@@ -280,10 +280,12 @@ function setRestoreTimer() {
         </div>
       </FormLayout>
     </template>
-    <NeSideDrawer :is-shown="showRestoreDrawer" title="" @close="showRestoreDrawer = false">
+    <NeSideDrawer
+      :is-shown="showRestoreDrawer"
+      :title="t('standalone.backup_and_restore.restore.restore_backup')"
+      @close="showRestoreDrawer = false"
+    >
       <div class="space-y-8">
-        <NeTitle>{{ t('standalone.backup_and_restore.restore.restore_backup') }}</NeTitle>
-        <hr />
         <template v-if="isEnterprise">
           <NeRadioSelection
             v-model="typeRestore"

--- a/src/components/standalone/backup_and_restore/SetPassphraseDrawer.vue
+++ b/src/components/standalone/backup_and_restore/SetPassphraseDrawer.vue
@@ -7,13 +7,7 @@
 import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ubusCall } from '@/lib/standalone/ubus'
-import {
-  NeTitle,
-  NeInlineNotification,
-  NeButton,
-  NeSideDrawer,
-  NeTooltip
-} from '@nethesis/vue-components'
+import { NeInlineNotification, NeButton, NeSideDrawer, NeTooltip } from '@nethesis/vue-components'
 import { getAxiosErrorMessage, NeTextInput } from '@nethserver/vue-tailwind-lib'
 import { AxiosError } from 'axios'
 

--- a/src/components/standalone/backup_and_restore/SetPassphraseDrawer.vue
+++ b/src/components/standalone/backup_and_restore/SetPassphraseDrawer.vue
@@ -76,10 +76,12 @@ async function setPassphrase() {
 </script>
 
 <template>
-  <NeSideDrawer :is-shown="showPassphraseDrawer" title="" @close="$emit('close')">
+  <NeSideDrawer
+    :is-shown="showPassphraseDrawer"
+    :title="t('standalone.backup_and_restore.backup.passphrase_drawer_title')"
+    @close="$emit('close')"
+  >
     <div class="space-y-8">
-      <NeTitle>{{ t('standalone.backup_and_restore.backup.passphrase_drawer_title') }}</NeTitle>
-      <hr />
       <NeTextInput
         v-model="formPassphrase.passphrase"
         :label="t('standalone.backup_and_restore.backup.passphrase')"

--- a/src/lib/standalone/fileUpload.ts
+++ b/src/lib/standalone/fileUpload.ts
@@ -19,7 +19,7 @@ export async function uploadFile(
   const formData = new FormData()
 
   formData.append('file', file)
-  return axios.post(`${getStandaloneApiEndpoint()}/upload`, formData, {
+  return axios.post(`${getStandaloneApiEndpoint()}/files`, formData, {
     headers: {
       'Content-Type': 'multipart/form-data',
       Authorization: `Bearer ${loginStore.token}`

--- a/src/lib/standalone/fileUpload.ts
+++ b/src/lib/standalone/fileUpload.ts
@@ -27,3 +27,23 @@ export async function uploadFile(
     onUploadProgress
   })
 }
+
+export async function downloadFile(filename: string) {
+  const loginStore = useLoginStore()
+  return axios.get(`${getStandaloneApiEndpoint()}/files/${filename}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${loginStore.token}`
+    }
+  })
+}
+
+export async function deleteFile(filename: string) {
+  const loginStore = useLoginStore()
+  return axios.delete(`${getStandaloneApiEndpoint()}/files/${filename}`, {
+    headers: {
+      'Content-Type': 'multipart/application/json',
+      Authorization: `Bearer ${loginStore.token}`
+    }
+  })
+}

--- a/src/lib/standalone/fileUpload.ts
+++ b/src/lib/standalone/fileUpload.ts
@@ -30,19 +30,21 @@ export async function uploadFile(
 
 export async function downloadFile(filename: string) {
   const loginStore = useLoginStore()
-  return axios.get(`${getStandaloneApiEndpoint()}/files/${filename}`, {
+  const fileResponse = await axios.get(`${getStandaloneApiEndpoint()}/files/${filename}`, {
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${loginStore.token}`
-    }
+    },
+    responseType: 'arraybuffer'
   })
+  return new Blob([fileResponse.data])
 }
 
 export async function deleteFile(filename: string) {
   const loginStore = useLoginStore()
   return axios.delete(`${getStandaloneApiEndpoint()}/files/${filename}`, {
     headers: {
-      'Content-Type': 'multipart/application/json',
+      'Content-Type': 'application/json',
       Authorization: `Bearer ${loginStore.token}`
     }
   })


### PR DESCRIPTION
- Refactor `fileUpload` lib to use the new `/api/files` end and add functions to download and delete file based on filename
- Use new api flow for backup, restore and migration to handle file uploads, allowing for larger file sizes on upload

Card: https://trello.com/c/k0b38yGx/380-ubus-fails-to-handle-files-larger-than-70k