### PR TITLE
fix: network lib, fix vlan over bond visualization

### DIFF
--- a/src/lib/standalone/network.ts
+++ b/src/lib/standalone/network.ts
@@ -291,7 +291,10 @@ export function isBridge(device: DeviceOrIface) {
 }
 
 export function isBond(deviceOrIface: DeviceOrIface) {
-  return deviceOrIface?.proto === 'bonding' || deviceOrIface.name?.startsWith('bond-')
+  return (
+    deviceOrIface?.proto === 'bonding' ||
+    (deviceOrIface.name?.startsWith('bond-') && !isVlan(deviceOrIface))
+  )
 }
 
 export function isUnconfiguredBond(deviceOrIface: DeviceOrIface) {


### PR DESCRIPTION
Before this commit, a vlan over a bond was rendered as a bond.

Card: https://github.com/NethServer/nethsecurity-ui/pull/217