### PR TITLE
Fix: avoid changing tabs when switching page

### DIFF
--- a/src/composables/useTabs.ts
+++ b/src/composables/useTabs.ts
@@ -19,14 +19,17 @@ export function useTabs(tabsList: Tab[], initialTabName?: string) {
 
   const tabs = ref(tabsList)
   const selectedTab = ref('')
+  const currentPath = route.path
 
   watch(
     () => route.query.tab,
     () => {
-      selectedTab.value =
-        (route.query.tab as string) ??
-        initialTabName ??
-        (tabs.value.length > 0 ? tabs.value[0].name : '')
+      if (route.path === currentPath) {
+        selectedTab.value =
+          (route.query.tab as string) ??
+          initialTabName ??
+          (tabs.value.length > 0 ? tabs.value[0].name : '')
+      }
     },
     { immediate: true }
   )


### PR DESCRIPTION
This PR fixes an issue occuring with the `useTabs` composable where, when switching page, the `watch` callback would be called on both the source page and the target one, causing a wrong tab value being set. To fix the issue, a check has been added to ensure the tab does not update if the current path is different compared to the page's route path.