### PR TITLE
Refactor useItemPagination composable to better handle reactivity

### DIFF
--- a/src/components/standalone/security/threat_shield/BlocklistTable.vue
+++ b/src/components/standalone/security/threat_shield/BlocklistTable.vue
@@ -23,7 +23,7 @@ defineEmits<{
   enableDisable: [item: Blocklist]
 }>()
 
-const { currentPage, pageCount, paginatedItems } = useItemPagination(props.blocklists, {
+const { currentPage, pageCount, paginatedItems } = useItemPagination(() => props.blocklists, {
   itemsPerPage: 10
 })
 

--- a/src/composables/useItemPagination.ts
+++ b/src/composables/useItemPagination.ts
@@ -1,5 +1,5 @@
 import { useOffsetPagination } from '@vueuse/core'
-import { computed, type Ref } from 'vue'
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
 
 export type ItemPaginationSettings = {
   itemsPerPage: number
@@ -9,25 +9,28 @@ export type ItemPaginationSettings = {
 /**
  * Composable that provides pagination functionality for an array of items,
  * returning the paginated items based on the current page.
- * @param {T[] | Ref<T[]>} items - The array of items to paginate.
+ * @param {MaybeRefOrGetter<T[]>} items - The array of items to paginate.
  * @param {ItemPaginationSettings} settings - The pagination settings, including the number of items per
  * page and an optional onPageChange callback.
  *
  * @example
  * const { currentPage, pageCount, paginatedItems, prev, next } = useItemPagination(items, { itemsPerPage: 10 });
  */
-export function useItemPagination<T>(items: T[] | Ref<T[]>, settings: ItemPaginationSettings) {
+export function useItemPagination<T>(
+  items: MaybeRefOrGetter<T[]>,
+  settings: ItemPaginationSettings
+) {
   const { currentPage, pageCount, prev, next } = useOffsetPagination({
     page: 1,
     pageSize: settings.itemsPerPage,
-    total: () => (Array.isArray(items) ? items.length : items.value.length),
+    total: () => toValue(items).length,
     onPageChange: settings.onPageChange
   })
 
   const paginatedItems = computed(() => {
     const start = (currentPage.value - 1) * settings.itemsPerPage
     const end = start + settings.itemsPerPage
-    const itemsArray = Array.isArray(items) ? items : items.value
+    const itemsArray = toValue(items)
     return itemsArray.slice(start, end)
   })
 


### PR DESCRIPTION
This PR refactors the `useItemPagination` composable to better handle reactivity, allowing its outputs to be refreshed when the input changes. To allow for reactivity, a ref or function getter has to be passed to the composable. An example could be the following:

```
const { currentPage, pageCount, paginatedItems } = useItemPagination(() => props.blocklists, {
  itemsPerPage: 10
})
```