### PR TITLE
Fix axios error when committing changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@vueuse/core": "^10.5.0",
         "@xterm/addon-attach": "^0.10.0",
         "@xterm/xterm": "^5.4.0",
-        "axios": "^1.4.0",
+        "axios": "^1.6.8",
         "chart.js": "^4.4.0",
         "chartjs-adapter-date-fns": "^3.0.0",
         "jwt-decode": "^4.0.0",
@@ -2283,11 +2283,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -3481,9 +3481,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@vueuse/core": "^10.5.0",
     "@xterm/addon-attach": "^0.10.0",
     "@xterm/xterm": "^5.4.0",
-    "axios": "^1.4.0",
+    "axios": "^1.6.8",
     "chart.js": "^4.4.0",
     "chartjs-adapter-date-fns": "^3.0.0",
     "jwt-decode": "^4.0.0",

--- a/src/stores/standalone/uciPendingChanges.ts
+++ b/src/stores/standalone/uciPendingChanges.ts
@@ -23,8 +23,12 @@ export const useUciPendingChangesStore = defineStore('uciPendingChanges', () => 
 
   const commitChanges = async () => {
     await ubusCall('ns.commit', 'commit', { changes: changes.value })
-    // reload page
-    location.reload()
+
+    // reload page using a timeout: some browsers (e.g. Firefox) detect an axios error if the page is reloaded just after a POST request
+
+    setTimeout(() => {
+      location.reload()
+    }, 200)
   }
 
   const revertChanges = async () => {


### PR DESCRIPTION
Some browsers (e.g. Firefox) detect an axios error if the page is reloaded just after a POST request.
This happens e.g. when committing UCI changes: the UI waits for the API call to complete and reload the page immediately after.
To mitigate this issue this PR just adds a `setTimeout` before the page reload.

Other changes:
- Bump axios version