### PR TITLE
DHCP & DNS: scan network

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -953,7 +953,7 @@
       "no_reservation_found": "No reservations found",
       "interfaces": "Interfaces",
       "active": "Active",
-      "not_active": "Not active",
+      "inactive": "Inactive",
       "options": "Options",
       "expand_all_cards": "Expand all cards",
       "collapse_all_cards": "Collapse all cards",

--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -326,7 +326,8 @@
     "cannot_retrieve_unit_ssh_port": "Cannot retrieve unit SSH port",
     "cannot_open_unit": "Cannot open unit",
     "cannot_retrieve_unit_ssh_keys": "Cannot retrieve unit SSH keys",
-    "cannot_remove_unit": "Cannot remove unit"
+    "cannot_remove_unit": "Cannot remove unit",
+    "cannot_scan_network": "Cannot scan network"
   },
   "ne_text_input": {
     "show_password": "Show password",
@@ -911,7 +912,8 @@
         "dns": "DNS",
         "static_leases": "Static leases",
         "dynamic_leases": "Dynamic leases",
-        "dns_records": "DNS records"
+        "dns_records": "DNS records",
+        "scan_network": "Scan network"
       },
       "dns_forwarding_servers": "DNS forwarding servers",
       "dns_forwarding_servers_tooltip": "Configure upstream DNS server IP addresses to route non-local domain queries to these servers. Enter the IP address of the remote DNS server. Use '/{'<'}domain{'>'}/{'<'}server{'>'}' syntax to route only requests for a specific domain to the given server. Use the '/{'<'}server{'>'}#{'<'}port{'>'}` syntax if the upstream server does not listen on a standard port.",
@@ -978,7 +980,16 @@
       "filter_change_suggestion": "Try changing filter value",
       "dhcp_option_combobox_placeholder": "Search key",
       "force_start": "Force DHCP server start",
-      "force_start_tooltip": "When force option is enabled, DHCP will start even if there is another DHCP server in the network. Disable force option only if you want to avoid conflicts with other DHCP servers."
+      "force_start_tooltip": "When force option is enabled, DHCP will start even if there is another DHCP server in the network. Disable force option only if you want to avoid conflicts with other DHCP servers.",
+      "scan_network_description": "Scan the network to discover devices and assign them IP reservations or DNS records.",
+      "scan_results": "Scan results",
+      "interface_name": "Interface: {name}",
+      "description": "Description",
+      "scan_network": "Scan network",
+      "scan_not_requested_empty_state": "Click 'Scan network' on an interface to discover devices",
+      "scan_no_results_empty_state": "No devices found on interface '{iface}'",
+      "reservation_location_info_description": "This reservation will appear in:",
+      "dns_record_location_info_description": "This DNS record will appear in:"
     },
     "routes": {
       "title": "Routes",

--- a/src/components/standalone/dns_dhcp/CreateOrEditStaticLeaseDrawer.vue
+++ b/src/components/standalone/dns_dhcp/CreateOrEditStaticLeaseDrawer.vue
@@ -26,11 +26,13 @@ import { useI18n } from 'vue-i18n'
 import { ValidationError, ubusCall } from '@/lib/standalone/ubus'
 import type { StaticLease } from './StaticLeases.vue'
 import type { DynamicLease } from './DynamicLeases.vue'
+import type { ScanResult } from './ScanNetwork.vue'
 
 const props = defineProps<{
   isShown: boolean
   itemToEdit?: StaticLease
   importDynamicLease?: DynamicLease
+  importScanResult?: ScanResult
 }>()
 
 const { t } = useI18n()
@@ -58,6 +60,12 @@ function resetForm() {
     hostname.value = props.importDynamicLease.hostname
     ipAddress.value = props.importDynamicLease.ipaddr
     macAddress.value = props.importDynamicLease.macaddr
+    reservationName.value = ''
+  } else if (props.importScanResult) {
+    id.value = ''
+    hostname.value = props.importScanResult.hostname || ''
+    ipAddress.value = props.importScanResult.ip
+    macAddress.value = props.importScanResult.mac
     reservationName.value = ''
   } else {
     id.value = props.itemToEdit?.lease ?? ''
@@ -160,6 +168,13 @@ watchEffect(() => {
 onMounted(() => {
   resetForm()
 })
+
+function getReservationLocation() {
+  const networkTitle = t('standalone.network.title')
+  const dnsDhcpTitle = t('standalone.dns_dhcp.title')
+  const staticLeasesTitle = t('standalone.dns_dhcp.tabs.static_leases')
+  return `${networkTitle} > ${dnsDhcpTitle} > ${staticLeasesTitle}`
+}
 </script>
 
 <template>
@@ -171,6 +186,22 @@ onMounted(() => {
       id ? t('standalone.dns_dhcp.edit_reservation') : t('standalone.dns_dhcp.add_reservation')
     "
   >
+    <!-- info notification if we are adding a static lease from dynamic leases or scan network pages -->
+    <NeInlineNotification
+      v-if="importDynamicLease || importScanResult"
+      kind="info"
+      :closeAriaLabel="t('common.close')"
+      class="mb-6"
+    >
+      <template #description>
+        <div>
+          {{ t('standalone.dns_dhcp.reservation_location_info_description') }}
+        </div>
+        <div class="font-semibold">
+          {{ getReservationLocation() }}
+        </div>
+      </template>
+    </NeInlineNotification>
     <NeInlineNotification
       v-if="error.notificationTitle"
       :title="error.notificationTitle"

--- a/src/components/standalone/dns_dhcp/DhcpManager.vue
+++ b/src/components/standalone/dns_dhcp/DhcpManager.vue
@@ -159,11 +159,11 @@ onMounted(() => {
       :title="t('standalone.dns_dhcp.no_interface_configured')"
       :icon="['fas', 'circle-info']"
     />
-    <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3" v-else>
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-2 2xl:grid-cols-3" v-else>
       <div
         v-for="(iface, ifaceName) in interfaces"
         :key="ifaceName"
-        :class="`bg-whitetext-sm overflow-hidden rounded-md border-l-4 text-gray-700 dark:bg-gray-950 dark:text-gray-200 sm:rounded-lg sm:shadow ${getBorderColorForInterface(
+        :class="`overflow-hidden rounded-md border-l-4 bg-white text-sm text-gray-700 dark:bg-gray-950 dark:text-gray-200 sm:rounded-lg sm:shadow ${getBorderColorForInterface(
           ifaceName
         )}`"
       >
@@ -178,9 +178,7 @@ onMounted(() => {
               <NeBadge
                 size="sm"
                 :text="
-                  iface.active
-                    ? t('standalone.dns_dhcp.active')
-                    : t('standalone.dns_dhcp.not_active')
+                  iface.active ? t('standalone.dns_dhcp.active') : t('standalone.dns_dhcp.inactive')
                 "
                 :kind="iface.active ? 'success' : 'secondary'"
               />

--- a/src/components/standalone/dns_dhcp/ScanInterfaceCard.vue
+++ b/src/components/standalone/dns_dhcp/ScanInterfaceCard.vue
@@ -1,0 +1,73 @@
+<!--
+  Copyright (C) 2024 Nethesis S.r.l.
+  SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { NeButton } from '@nethesis/vue-components'
+import { type PropType } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useFirewallStore } from '@/stores/standalone/firewall'
+import { getZoneBorderColorClasses } from '@/lib/standalone/network'
+import type { ScanInterface } from './ScanNetwork.vue'
+
+defineProps({
+  iface: {
+    type: Object as PropType<ScanInterface>,
+    required: true
+  },
+  scanButtonLoading: {
+    type: Boolean,
+    default: false
+  },
+  scanButtonDisabled: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emit = defineEmits(['startScan'])
+
+const { t } = useI18n()
+const firewallConfig = useFirewallStore()
+
+function getBorderColorForInterface(iface: string) {
+  const interfaceZone = firewallConfig.zones.find((zone) => zone.interfaces.includes(iface))
+  return getZoneBorderColorClasses(interfaceZone?.name ?? '')
+}
+</script>
+
+<template>
+  <div
+    :class="`overflow-hidden rounded-md border-l-4 bg-white text-sm text-gray-700 dark:bg-gray-950 dark:text-gray-200 sm:rounded-lg sm:shadow ${getBorderColorForInterface(
+      iface.name
+    )}`"
+  >
+    <div class="flex grow flex-col gap-y-4 p-5">
+      <div class="flex flex-col">
+        <div class="flex flex-row items-center justify-between">
+          <p class="text-sm">
+            <strong>{{ iface.name }}</strong>
+            <br />
+            {{ iface.device }}
+          </p>
+          <NeButton
+            kind="tertiary"
+            @click="emit('startScan', iface)"
+            :loading="scanButtonLoading"
+            :disabled="scanButtonDisabled"
+          >
+            <template #prefix>
+              <font-awesome-icon
+                :icon="['fas', 'magnifying-glass']"
+                class="h-4 w-4"
+                aria-hidden="true"
+              />
+            </template>
+            {{ t('standalone.dns_dhcp.scan_network') }}
+          </NeButton>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/standalone/dns_dhcp/ScanNetwork.vue
+++ b/src/components/standalone/dns_dhcp/ScanNetwork.vue
@@ -1,0 +1,232 @@
+<!--
+  Copyright (C) 2024 Nethesis S.r.l.
+  SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import {
+  NeTitle,
+  NeInlineNotification,
+  getAxiosErrorMessage,
+  NeEmptyState
+} from '@nethesis/vue-components'
+import { onMounted } from 'vue'
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
+import { useFirewallStore } from '@/stores/standalone/firewall'
+import { computed } from 'vue'
+import { isEmpty } from 'lodash-es'
+import ScanInterfaceCard from './ScanInterfaceCard.vue'
+import ScanResultsTable from './ScanResultsTable.vue'
+import CreateOrEditStaticLeaseDrawer from './CreateOrEditStaticLeaseDrawer.vue'
+import CreateOrEditDnsRecordDrawer from './CreateOrEditDnsRecordDrawer.vue'
+import { ubusCall } from '@/lib/standalone/ubus'
+
+export interface ScanInterface {
+  name: string
+  device: string
+}
+
+export interface ScanResult {
+  ip: string
+  mac: string
+  hostname?: string
+  description?: string
+}
+
+const { t } = useI18n()
+const uciChangesStore = useUciPendingChangesStore()
+const firewallConfig = useFirewallStore()
+
+const scanningInterface = ref<string>('')
+const interfaces = ref<ScanInterface[]>([])
+const scanResults = ref<ScanResult[]>([])
+const scanRequested = ref(false)
+const currentScanResult = ref<ScanResult | undefined>(undefined)
+const isAddReservationDrawerShown = ref(false)
+const isAddDnsRecordDrawerShown = ref(false)
+
+const loading = ref({
+  listInterfaces: true,
+  scanNetwork: false
+})
+const error = ref({
+  listInterfaces: '',
+  listInterfacesDetails: '',
+  scanNetwork: '',
+  scanNetworkDetails: ''
+})
+
+const isLoadingData = computed(() => {
+  return loading.value.listInterfaces || firewallConfig.loading
+})
+
+onMounted(() => {
+  if (firewallConfig.loading || firewallConfig.error) {
+    firewallConfig.fetch()
+  }
+  listInterfaces()
+})
+
+async function listInterfaces() {
+  loading.value.listInterfaces = true
+
+  try {
+    const res = await ubusCall('ns.scan', 'list-interfaces')
+    interfaces.value = res.data.interfaces.map((iface: any) => ({
+      name: iface.interface,
+      device: iface.device
+    }))
+  } catch (err: any) {
+    error.value.listInterfaces = t(getAxiosErrorMessage(err))
+    error.value.listInterfacesDetails = err.toString()
+  } finally {
+    loading.value.listInterfaces = false
+  }
+}
+
+async function scanNetwork(iface: ScanInterface) {
+  error.value.scanNetwork = ''
+  error.value.scanNetworkDetails = ''
+  scanningInterface.value = iface.name
+  scanRequested.value = true
+  loading.value.scanNetwork = true
+
+  try {
+    const res = await ubusCall('ns.scan', 'scan', { device: iface.device })
+    scanResults.value = res.data.hosts.map((host: ScanResult) => ({
+      ip: host.ip,
+      mac: host.mac,
+      hostname: host.hostname !== host.ip ? host.hostname : '',
+      description: host.description
+    }))
+  } catch (err: any) {
+    error.value.scanNetwork = t(getAxiosErrorMessage(err))
+    error.value.scanNetworkDetails = err.toString()
+  } finally {
+    loading.value.scanNetwork = false
+  }
+}
+
+function addIpReservation(scanResult: ScanResult) {
+  currentScanResult.value = scanResult
+  isAddReservationDrawerShown.value = true
+}
+
+function addDnsRecord(scanResult: ScanResult) {
+  currentScanResult.value = scanResult
+  isAddDnsRecordDrawerShown.value = true
+}
+</script>
+
+<template>
+  <div>
+    <div class="space-y-8">
+      <p class="max-w-2xl text-gray-500 dark:text-gray-400">
+        {{ t('standalone.dns_dhcp.scan_network_description') }}
+      </p>
+      <!-- list interfaces error -->
+      <NeInlineNotification
+        v-if="error.listInterfaces"
+        kind="error"
+        :title="t('error.cannot_retrieve_interfaces')"
+        :description="error.listInterfaces"
+        class="mb-4"
+      >
+        <template #details v-if="error.listInterfacesDetails">
+          {{ error.listInterfacesDetails }}
+        </template>
+      </NeInlineNotification>
+      <!-- interfaces -->
+      <div>
+        <NeTitle level="h4" class="mb-4">{{ t('standalone.dns_dhcp.interfaces') }}</NeTitle>
+        <!-- scan error -->
+        <NeInlineNotification
+          v-if="error.scanNetwork"
+          kind="error"
+          :title="t('error.cannot_scan_network')"
+          :description="error.scanNetwork"
+          class="mb-4"
+        >
+          <template #details v-if="error.scanNetworkDetails">
+            {{ error.scanNetworkDetails }}
+          </template>
+        </NeInlineNotification>
+        <!-- empty state -->
+        <NeEmptyState
+          v-if="!isLoadingData && Object.keys(interfaces).length == 0"
+          :title="t('standalone.dns_dhcp.no_interface_configured')"
+          :icon="['fas', 'circle-info']"
+        />
+        <div v-else class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3 3xl:grid-cols-4">
+          <!-- interface cards skeleton -->
+          <template v-if="isLoadingData">
+            <div v-for="index in 8" :key="index" class="flex animate-pulse">
+              <div class="h-24 w-full bg-gray-300 dark:bg-gray-700 sm:rounded-lg"></div>
+            </div>
+          </template>
+          <!-- interface cards -->
+          <template v-else>
+            <ScanInterfaceCard
+              v-for="(iface, ifaceName) in interfaces"
+              :key="ifaceName"
+              :iface="iface"
+              :scanButtonLoading="loading.scanNetwork && scanningInterface === iface.name"
+              :scanButtonDisabled="loading.scanNetwork && scanningInterface === iface.name"
+              @startScan="scanNetwork"
+            />
+          </template>
+        </div>
+      </div>
+      <!-- scan results -->
+      <div v-if="!isLoadingData">
+        <NeTitle level="h4" class="mb-4">{{ t('standalone.dns_dhcp.scan_results') }}</NeTitle>
+        <!-- empty state -->
+        <template v-if="!loading.scanNetwork && isEmpty(scanResults)">
+          <!-- no results -->
+          <NeEmptyState
+            v-if="scanRequested"
+            :title="
+              t('standalone.dns_dhcp.scan_no_results_empty_state', { iface: scanningInterface })
+            "
+            :icon="['fas', 'circle-info']"
+          />
+          <!-- scan not requested yet -->
+          <NeEmptyState
+            v-else
+            :title="t('standalone.dns_dhcp.scan_not_requested_empty_state')"
+            :icon="['fas', 'network-wired']"
+          />
+        </template>
+        <template v-else>
+          <p
+            class="z-0 -mb-1 table max-w-md rounded-se-md rounded-ss-md bg-indigo-300 p-2 text-sm dark:bg-indigo-800"
+          >
+            {{ t('standalone.dns_dhcp.interface_name', { name: scanningInterface }) }}
+          </p>
+          <ScanResultsTable
+            :results="scanResults"
+            :loading="loading.scanNetwork"
+            @addIpReservation="addIpReservation"
+            @addDnsRecord="addDnsRecord"
+          />
+        </template>
+      </div>
+    </div>
+    <!-- add reservation drawer -->
+    <CreateOrEditStaticLeaseDrawer
+      :isShown="isAddReservationDrawerShown"
+      :importScanResult="currentScanResult"
+      @close="isAddReservationDrawerShown = false"
+      @add-edit-lease="uciChangesStore.getChanges()"
+    />
+    <!-- add dns record drawer -->
+    <CreateOrEditDnsRecordDrawer
+      :isShown="isAddDnsRecordDrawerShown"
+      :importScanResult="currentScanResult"
+      @close="isAddDnsRecordDrawerShown = false"
+      @add-edit-record="uciChangesStore.getChanges()"
+    />
+  </div>
+</template>

--- a/src/components/standalone/dns_dhcp/ScanResultsTable.vue
+++ b/src/components/standalone/dns_dhcp/ScanResultsTable.vue
@@ -1,0 +1,116 @@
+<!--
+  Copyright (C) 2024 Nethesis S.r.l.
+  SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { NeDropdown, useItemPagination } from '@nethesis/vue-components'
+import { type PropType } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { ScanResult } from './ScanNetwork.vue'
+import NeTable from '../NeTable.vue'
+
+const props = defineProps({
+  results: {
+    type: Array as PropType<ScanResult[]>,
+    required: true
+  },
+  loading: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emit = defineEmits(['addIpReservation', 'addDnsRecord'])
+
+const { t } = useI18n()
+
+const { currentPage, pageCount, paginatedItems } = useItemPagination(() => props.results, {
+  itemsPerPage: 10
+})
+
+const tableHeaders = [
+  {
+    label: t('standalone.dns_dhcp.ip_address'),
+    key: 'ip'
+  },
+  {
+    label: t('standalone.dns_dhcp.mac_address'),
+    key: 'mac'
+  },
+  {
+    label: t('standalone.dns_dhcp.hostname'),
+    key: 'hostname'
+  },
+  {
+    label: t('standalone.dns_dhcp.description'),
+    key: 'description'
+  },
+  {
+    key: 'actions'
+  }
+]
+
+function getKebabMenuItems(scanResult: ScanResult) {
+  return [
+    {
+      id: 'addIpReservation',
+      label: t('standalone.dns_dhcp.add_reservation'),
+      icon: 'circle-plus',
+      iconStyle: 'fas',
+      action: () => emit('addIpReservation', scanResult)
+    },
+    {
+      id: 'addDnsRecord',
+      label: t('standalone.dns_dhcp.add_dns_record'),
+      icon: 'circle-plus',
+      iconStyle: 'fas',
+      action: () => emit('addDnsRecord', scanResult)
+    }
+  ]
+}
+</script>
+
+<template>
+  <NeTable
+    :data="paginatedItems"
+    :with-paginator="true"
+    :paginator-props="{
+      totalPages: pageCount,
+      currentPage,
+      previousLabel: t('common.previous'),
+      nextLabel: t('common.next')
+    }"
+    @select-page="
+      (page) => {
+        currentPage = page
+      }
+    "
+    :headers="tableHeaders"
+    :loading="loading"
+    :skeletonLines="8"
+  >
+    <!-- ip -->
+    <template #ip="{ item }: { item: ScanResult }">
+      {{ item.ip || '-' }}
+    </template>
+    <!-- mac -->
+    <template #mac="{ item }: { item: ScanResult }">
+      {{ item.mac || '-' }}
+    </template>
+    <!-- hostname -->
+    <template #hostname="{ item }: { item: ScanResult }">
+      {{ item.hostname || '-' }}
+    </template>
+    <!-- description -->
+    <template #description="{ item }: { item: ScanResult }">
+      {{ item.description || '-' }}
+    </template>
+    <!-- actions -->
+    <template #actions="{ item }: { item: ScanResult }">
+      <div class="flex justify-end">
+        <NeDropdown :items="getKebabMenuItems(item)" :alignToRight="true" />
+      </div>
+    </template>
+  </NeTable>
+</template>

--- a/src/views/standalone/network/DnsDhcpView.vue
+++ b/src/views/standalone/network/DnsDhcpView.vue
@@ -11,6 +11,7 @@ import StaticLeases from '@/components/standalone/dns_dhcp/StaticLeases.vue'
 import DynamicLeases from '@/components/standalone/dns_dhcp/DynamicLeases.vue'
 import DnsManager from '@/components/standalone/dns_dhcp/DnsManager.vue'
 import DnsRecords from '@/components/standalone/dns_dhcp/DnsRecords.vue'
+import ScanNetwork from '@/components/standalone/dns_dhcp/ScanNetwork.vue'
 import { useTabs } from '@/composables/useTabs'
 
 const { t } = useI18n()
@@ -35,6 +36,10 @@ const { tabs, selectedTab } = useTabs([
   {
     name: 'dns-records',
     label: t('standalone.dns_dhcp.tabs.dns_records')
+  },
+  {
+    name: 'scan-network',
+    label: t('standalone.dns_dhcp.tabs.scan_network')
   }
 ])
 </script>
@@ -54,6 +59,7 @@ const { tabs, selectedTab } = useTabs([
     <StaticLeases v-else-if="selectedTab === 'static-leases'" />
     <DynamicLeases v-else-if="selectedTab === 'dynamic-leases'" />
     <DnsManager v-else-if="selectedTab === 'dns'" />
-    <DnsRecords v-else />
+    <DnsRecords v-else-if="selectedTab === 'dns-records'" />
+    <ScanNetwork v-else />
   </div>
 </template>


### PR DESCRIPTION
Add **Scan network** tab in **DHCP & DNS** page. It is used to discover devices and assign them IP reservations or DNS records.

See:
- https://github.com/NethServer/nethsecurity/issues/460