### PR TITLE
fix: ipsec tunnel, hide skeleton after first load

### DIFF
--- a/src/views/standalone/vpn/IPsecTunnelView.vue
+++ b/src/views/standalone/vpn/IPsecTunnelView.vue
@@ -54,7 +54,7 @@ async function fetchTunnels(setLoading: boolean = true) {
     error.value.notificationDetails = err.toString()
   } finally {
     if (setLoading) {
-      loading.value = true
+      loading.value = false
     }
   }
 }


### PR DESCRIPTION
Previously, the skeleton was visible until the first execution of the interval

Related to https://github.com/NethServer/nethsecurity-ui/pull/251