### PR TITLE
Show a warning on the dashboard if DNS is not configured

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+  "recommendations": ["Vue.volar"]
 }

--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -420,7 +420,9 @@
       "blocked_ips_last_hour": "IPs blocked in the last hour",
       "clients_connected": "clients connected",
       "tunnels_enabled": "tunnel enabled | tunnels enabled",
-      "tunnels_connected": "tunnel connected | tunnels connected"
+      "tunnels_connected": "tunnel connected | tunnels connected",
+      "dns_not_configured_tooltip": "You're using one or more WANs with a static IP: make sure to configure at least one DNS forwarder. Go to {dnsLink}",
+      "check_dns_configuration": "Check DNS"
     },
     "subscription": {
       "title": "Subscription",

--- a/src/ControllerApp.vue
+++ b/src/ControllerApp.vue
@@ -123,7 +123,7 @@ function configureAxios() {
             notificationsStore.createNotificationFromAxiosError(error)
           }
         } else {
-          if (error.response?.data?.message === 'Token is expired') {
+          if (error.response?.data?.message !== 'incorrect Username or Password') {
             console.warn('[interceptor]', 'Detected error 401, logout')
             loginStore.isSessionExpired = true
             loginStore.logout()

--- a/src/StandaloneApp.vue
+++ b/src/StandaloneApp.vue
@@ -109,7 +109,7 @@ function configureAxios() {
 
       if (error.response?.status == 401) {
         if (isStandaloneMode()) {
-          if (error.response?.data?.message === 'Token is expired') {
+          if (error.response?.data?.message !== 'incorrect Username or Password') {
             console.warn('[interceptor]', 'Detected error 401, logout')
             loginStore.isSessionExpired = true
             loginStore.logout()

--- a/src/components/AxiosErrorModal.vue
+++ b/src/components/AxiosErrorModal.vue
@@ -88,7 +88,7 @@ function copyCommandToClipboard() {
         <div class="mb-1">{{ t('error_modal.report_issue_description') }}:</div>
         <ol class="list-inside list-decimal">
           <li>
-            <i18n-t keypath="error_modal.report_issue_step_1" tag="span">
+            <i18n-t keypath="error_modal.report_issue_step_1" tag="span" scope="global">
               <template #copyTheCommand>
                 <NeTooltip v-if="justCopied" triggerEvent="mouseenter focus" placement="top-start">
                   <template #trigger>

--- a/src/components/standalone/certificates/CreateLetsEncryptCertificateDrawer.vue
+++ b/src/components/standalone/certificates/CreateLetsEncryptCertificateDrawer.vue
@@ -294,7 +294,11 @@ watch(
             ><template #tooltip>
               <NeTooltip>
                 <template #content>
-                  <i18n-t keypath="standalone.certificates.dns_api_tooltip" tag="span">
+                  <i18n-t
+                    keypath="standalone.certificates.dns_api_tooltip"
+                    tag="span"
+                    scope="global"
+                  >
                     <template #dnsapiurl>
                       <NeLink
                         invertedTheme

--- a/src/components/standalone/dashboard/InternetConnectionCard.vue
+++ b/src/components/standalone/dashboard/InternetConnectionCard.vue
@@ -1,0 +1,177 @@
+<!--
+  Copyright (C) 2024 Nethesis S.r.l.
+  SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { ubusCall } from '@/lib/standalone/ubus'
+import { NeBadge, NeCard, NeLink, NeTooltip, getAxiosErrorMessage } from '@nethesis/vue-components'
+import { onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { faCheck, faWarning, faXmark } from '@fortawesome/free-solid-svg-icons'
+import { getStandaloneRoutePrefix } from '@/lib/router'
+import { useRoute, useRouter } from 'vue-router'
+
+const { t } = useI18n()
+const router = useRouter()
+const route = useRoute()
+
+// random refresh interval between 20 and 30 seconds
+const REFRESH_INTERVAL = 20000 + Math.random() * 10 * 1000
+const internetStatus = ref<any>(null)
+const dnsConfiguredStatus = ref<any>(null)
+const statusIntervalId = ref(0)
+
+let loading = ref({
+  getInternetStatus: false,
+  getDnsConfiguredStatus: false
+})
+
+let error = ref({
+  title: '',
+  description: ''
+})
+
+onMounted(() => {
+  loadData()
+
+  // periodically reload data
+  statusIntervalId.value = setInterval(loadData, REFRESH_INTERVAL)
+})
+
+onUnmounted(() => {
+  if (statusIntervalId.value) {
+    clearInterval(statusIntervalId.value)
+  }
+})
+
+function loadData() {
+  fetchInternetStatus()
+  fetchDnsConfiguredStatus()
+}
+
+async function fetchInternetStatus() {
+  // show skeleton only the first time
+  if (!statusIntervalId.value) {
+    loading.value.getInternetStatus = true
+  }
+  error.value.title = ''
+  error.value.description = ''
+
+  try {
+    const res = await ubusCall('ns.dashboard', 'service-status', { service: 'internet' })
+    internetStatus.value = res.data.result.status
+  } catch (err: any) {
+    console.error(err)
+    error.value.title = t('error.cannot_retrieve_service_status')
+    error.value.description = t(getAxiosErrorMessage(err))
+  } finally {
+    loading.value.getInternetStatus = false
+  }
+}
+
+async function fetchDnsConfiguredStatus() {
+  // show skeleton only the first time
+  if (!statusIntervalId.value) {
+    loading.value.getDnsConfiguredStatus = true
+  }
+  error.value.title = ''
+  error.value.description = ''
+
+  try {
+    const res = await ubusCall('ns.dashboard', 'service-status', { service: 'dns-configured' })
+    dnsConfiguredStatus.value = res.data.result.status
+  } catch (err: any) {
+    console.error(err)
+    error.value.title = t('error.cannot_retrieve_service_status')
+    error.value.description = t(getAxiosErrorMessage(err))
+  } finally {
+    loading.value.getDnsConfiguredStatus = false
+  }
+}
+
+function getBadgeKind(status: string) {
+  switch (status) {
+    case 'ok':
+      return 'success'
+    case 'warning':
+      return 'warning'
+    case 'disabled':
+      return 'secondary'
+    default:
+      return 'error'
+  }
+}
+
+function getBadgeText(status: string) {
+  switch (status) {
+    case 'ok':
+      return t('standalone.dashboard.active')
+    case 'warning':
+      return t('standalone.dashboard.warning')
+    case 'disabled':
+      return t('standalone.dashboard.inactive')
+    default:
+      return t('standalone.dashboard.unknown')
+  }
+}
+
+function getBadgeIcon(status: string) {
+  switch (status) {
+    case 'ok':
+      return faCheck
+    case 'warning':
+      return faWarning
+    case 'disabled':
+      return faXmark
+    default:
+      return faXmark
+  }
+}
+
+function goToDns() {
+  router.push(`${getStandaloneRoutePrefix(route)}/network/dns-dhcp?tab=dns`)
+}
+</script>
+
+<template>
+  <NeCard
+    :title="t('standalone.dashboard.internet_connection')"
+    :icon="['fas', 'earth-americas']"
+    :skeletonLines="2"
+    :loading="loading.getInternetStatus || loading.getDnsConfiguredStatus"
+    :errorTitle="error.title"
+    :errorDescription="error.description"
+  >
+    <div class="space-y-4">
+      <NeBadge
+        :kind="getBadgeKind(internetStatus)"
+        :text="getBadgeText(internetStatus)"
+        :icon="getBadgeIcon(internetStatus)"
+      />
+      <NeTooltip v-if="dnsConfiguredStatus === 'warning'" class="block">
+        <template #trigger>
+          <div class="flex items-center gap-2">
+            <font-awesome-icon
+              :icon="['fas', 'warning']"
+              class="h-4 w-4 text-amber-700 dark:text-amber-500"
+              aria-hidden="true"
+            />
+            <NeLink class="text-left">
+              {{ t('standalone.dashboard.check_dns_configuration') }}
+            </NeLink>
+          </div>
+        </template>
+        <template #content>
+          <i18n-t keypath="standalone.dashboard.dns_not_configured_tooltip" tag="p" scope="global">
+            <template #dnsLink>
+              <NeLink invertedTheme @click="goToDns">
+                {{ t('standalone.dns_dhcp.title') }}
+              </NeLink>
+            </template>
+          </i18n-t>
+        </template>
+      </NeTooltip>
+    </div>
+  </NeCard>
+</template>

--- a/src/components/standalone/dashboard/SystemInfoCard.vue
+++ b/src/components/standalone/dashboard/SystemInfoCard.vue
@@ -183,7 +183,11 @@ async function getUpdatesStatus() {
               />
             </template>
             <template #content>
-              <i18n-t keypath="standalone.dashboard.default_hostname_warning" tag="p">
+              <i18n-t
+                keypath="standalone.dashboard.default_hostname_warning"
+                tag="p"
+                scope="global"
+              >
                 <template #systemSettingsLink>
                   <NeLink invertedTheme @click="goToSystemSettings">
                     {{ t('standalone.system_settings.title') }}

--- a/src/components/standalone/security/FlashstartContent.vue
+++ b/src/components/standalone/security/FlashstartContent.vue
@@ -225,7 +225,7 @@ function save() {
   <div>
     <FormLayout :title="t('standalone.flashstart.content_title')" class="max-w-3xl">
       <template #description>
-        <i18n-t keypath="standalone.flashstart.content_description" tag="p">
+        <i18n-t keypath="standalone.flashstart.content_description" tag="p" scope="global">
           <template #createAccount>
             <NeLink href="https://flashstart.nethesis.it/" target="_blank">
               {{ t('standalone.flashstart.content_link') }}
@@ -270,7 +270,7 @@ function save() {
             <template #tooltip>
               <NeTooltip>
                 <template #content>
-                  <i18n-t keypath="standalone.flashstart.username_helper" tag="span">
+                  <i18n-t keypath="standalone.flashstart.username_helper" tag="span" scope="global">
                     <template #flashstartUrl>
                       <NeLink invertedTheme href="https://flashstart.nethesis.it/" target="_blank">
                         https://flashstart.nethesis.it/

--- a/src/views/standalone/StandaloneDashboardView.vue
+++ b/src/views/standalone/StandaloneDashboardView.vue
@@ -16,6 +16,7 @@ import { getStandaloneRoutePrefix } from '@/lib/router'
 import router from '@/router'
 import { useRoute } from 'vue-router'
 import OpenVpnTunnelOrIpsecCard from '@/components/standalone/dashboard/OpenVpnTunnelOrIpsecCard.vue'
+import InternetConnectionCard from '@/components/standalone/dashboard/InternetConnectionCard.vue'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -48,12 +49,7 @@ function goTo(path: string) {
     <!-- system -->
     <SystemInfoCard class="sm:col-span-2 xl:row-span-3" />
     <!-- internet connection -->
-    <ServiceCard
-      serviceName="internet"
-      hasStatus
-      :title="t('standalone.dashboard.internet_connection')"
-      :icon="['fas', 'earth-americas']"
-    />
+    <InternetConnectionCard />
     <!-- multiwan -->
     <ServiceCard serviceName="mwan" hasStatus :icon="['fas', 'earth-americas']">
       <template #title>


### PR DESCRIPTION
Dashboard page: show a warning on **Internet connection** card if there are one or more WANs with a static IP address and no DNS forwarder has been configured.

Other changes:
- Fix logout on 401 error
- Fix warning for `<i18n-t>` elements
- Remove suggestion for deprecated vscode extension