### PR TITLE
Fix validation of selected restore file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@nethesis/nethesis-brands-svg-icons": "github:nethesis/Font-Awesome#ns-brands",
         "@nethesis/nethesis-light-svg-icons": "github:nethesis/Font-Awesome#ns-light",
         "@nethesis/nethesis-solid-svg-icons": "github:nethesis/Font-Awesome#ns-solid",
-        "@nethesis/vue-components": "^1.1.0",
+        "@nethesis/vue-components": "^1.2.0",
         "@types/lodash-es": "^4.17.12",
         "@vuepic/vue-datepicker": "^7.2.2",
         "@vueuse/core": "^10.5.0",
@@ -1314,9 +1314,9 @@
       }
     },
     "node_modules/@nethesis/vue-components": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nethesis/vue-components/-/vue-components-1.1.0.tgz",
-      "integrity": "sha512-J05RBu4lCsXLgcdTnMRsTpTENS/Y4sSTpyY1E//nTaCIF67/Yu5PBNegO1Q6LZjnrYBIKQYlspYpjP/CqE8pCg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@nethesis/vue-components/-/vue-components-1.2.0.tgz",
+      "integrity": "sha512-zZeJajXKvwtF5sgXiacv6tnRG8v40mUmesB6QPqdHcnllb8tn6mX+riAQEEyAd0ZEkby+VZt0kGsr6kTI2ZKlw==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
@@ -1327,7 +1327,7 @@
         "date-fns-tz": "^2.0.0",
         "lodash-es": "^4.17.21",
         "uuid": "^9.0.1",
-        "vue": "^3.3.4",
+        "vue": "^3.4.27",
         "vue-tippy": "^6.3.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@nethesis/nethesis-brands-svg-icons": "github:nethesis/Font-Awesome#ns-brands",
     "@nethesis/nethesis-light-svg-icons": "github:nethesis/Font-Awesome#ns-light",
     "@nethesis/nethesis-solid-svg-icons": "github:nethesis/Font-Awesome#ns-solid",
-    "@nethesis/vue-components": "^1.1.0",
+    "@nethesis/vue-components": "^1.2.0",
     "@types/lodash-es": "^4.17.12",
     "@vuepic/vue-datepicker": "^7.2.2",
     "@vueuse/core": "^10.5.0",

--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -570,7 +570,7 @@
         "backup": "Backup",
         "from_backup": "From last backups",
         "from_file": "Upload file",
-        "upload_file": "Backup file (*.tar.gz or *.tar.gz.gpg)"
+        "upload_file": "Backup file ({extensions})"
       },
       "migration": {
         "description": "Migration is the process to convert a NethServer 7 machine into a NethSecurity. To initiate the process, access the NethServer 7 machine and create a migration archive, which should then be uploaded on this page. Following the upload, ensure the proper remapping of old network interfaces to those within the hardware hosting NethSecurity.",

--- a/src/components/controller/units/SendOrRevokeSshKeyDrawer.vue
+++ b/src/components/controller/units/SendOrRevokeSshKeyDrawer.vue
@@ -9,7 +9,7 @@ import {
   NeSideDrawer,
   NeButton,
   NeCombobox,
-  NeComboboxOption,
+  type NeComboboxOption,
   focusElement,
   NeSkeleton
 } from '@nethesis/vue-components'

--- a/src/components/standalone/backup_and_restore/RestoreContent.vue
+++ b/src/components/standalone/backup_and_restore/RestoreContent.vue
@@ -23,7 +23,7 @@ import {
 } from '@nethesis/vue-components'
 import { NeModal } from '@nethesis/vue-components'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { validateFile, validateRequired } from '@/lib/validation'
+import { validateRequired } from '@/lib/validation'
 import FormLayout from '@/components/standalone/FormLayout.vue'
 import { uploadFile } from '@/lib/standalone/fileUpload'
 
@@ -226,22 +226,10 @@ async function restoreBackup() {
 }
 
 async function handleFileUpload() {
-  errorRestore.value.file = ''
   isUploadingBackupFile.value = false
   canRestoreBackupFile.value = false
 
   if (!formRestore.value.file) {
-    return
-  }
-
-  const tarGzFileValidation = validateFile(formRestore.value.file as File | null, 'tar.gz')
-  const tarGzGpgFileValidation = validateFile(formRestore.value.file as File | null, 'tar.gz.gpg')
-
-  if (!tarGzFileValidation.valid && tarGzGpgFileValidation.valid) {
-    const validatorErrMessage = !tarGzFileValidation.valid
-      ? tarGzFileValidation.errMessage
-      : tarGzGpgFileValidation.errMessage
-    errorRestore.value.file = t(validatorErrMessage as string)
     return
   }
 
@@ -341,11 +329,16 @@ function setRestoreTimer() {
         </template>
         <template v-if="typeRestore === 'upload_file'">
           <NeFileInput
-            :label="t('standalone.backup_and_restore.restore.upload_file')"
+            :label="
+              t('standalone.backup_and_restore.restore.upload_file', {
+                extensions: '*.tar.gz, *.tar.gz.gpg, *.bin'
+              })
+            "
             :dropzoneLabel="t('ne_file_input.dropzone_label')"
             :invalid-message="errorRestore.file"
             @select="handleFileUpload"
             v-model="formRestore.file"
+            accept=".tar.gz,.tar.gz.gpg,.bin"
             ref="fileRef"
           />
         </template>


### PR DESCRIPTION
Simplify validation of selected restore file by:
- Removing manual file name syntax validation
- Restricting the type of files that can be selected for the restore

See:
- https://github.com/nethesis/vue-components/pull/58