### PR TITLE
add tooltip for ports in RuleEditor.vue

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -882,7 +882,7 @@
       "source_port": "Source Port",
       "destination_address": "Destination Address",
       "destination_port": "Destination Port",
-      "ports_tooltip": "Enter a single port, multiple ports separated by a comma (e.g. '8686, 9090') and/or port ranges (e.g. '5500-5600')",
+      "ports_tooltip": "Enter a single port, multiple ports separated by a comma (e.g. '8686, 9090') or port ranges (e.g. '5500-5600')",
       "protocol": "Protocol",
       "edit_rule": "Edit {name} rule",
       "priority": "Priority {n}",

--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -882,6 +882,7 @@
       "source_port": "Source Port",
       "destination_address": "Destination Address",
       "destination_port": "Destination Port",
+      "ports_tooltip": "Enter a single port, multiple ports separated by a comma (e.g. '8686, 9090') and/or port ranges (e.g. '5500-5600')",
       "protocol": "Protocol",
       "edit_rule": "Edit {name} rule",
       "priority": "Priority {n}",

--- a/src/components/standalone/multi-wan/RuleCreator.vue
+++ b/src/components/standalone/multi-wan/RuleCreator.vue
@@ -4,7 +4,13 @@
 -->
 
 <script lang="ts" setup>
-import { NeCombobox, NeButton, NeSideDrawer, NeTextInput } from '@nethesis/vue-components'
+import {
+  NeCombobox,
+  NeButton,
+  NeSideDrawer,
+  NeTextInput,
+  NeTooltip
+} from '@nethesis/vue-components'
 import { ref, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { Policy } from '@/composables/useMwan'
@@ -142,7 +148,15 @@ function save() {
         :label="t('standalone.multi_wan.source_port')"
         :placeholder="t('standalone.multi_wan.any')"
         name="source_port"
-      />
+      >
+        <template #tooltip>
+          <NeTooltip>
+            <template #content>
+              {{ t('standalone.multi_wan.ports_tooltip') }}
+            </template>
+          </NeTooltip>
+        </template>
+      </NeTextInput>
       <NeTextInput
         v-model="destinationAddress"
         :disabled="saving"
@@ -159,7 +173,15 @@ function save() {
         :label="t('standalone.multi_wan.destination_port')"
         :placeholder="t('standalone.multi_wan.any')"
         name="destination_port"
-      />
+      >
+        <template #tooltip>
+          <NeTooltip>
+            <template #content>
+              {{ t('standalone.multi_wan.ports_tooltip') }}
+            </template>
+          </NeTooltip>
+        </template>
+      </NeTextInput>
       <hr />
       <div class="flex justify-end gap-4">
         <NeButton :disabled="saving" :kind="'secondary'" @click="close()">

--- a/src/components/standalone/multi-wan/RuleEditor.vue
+++ b/src/components/standalone/multi-wan/RuleEditor.vue
@@ -6,7 +6,13 @@
 <script lang="ts" setup>
 import { useI18n } from 'vue-i18n'
 import { ref, toRef } from 'vue'
-import { NeCombobox, NeButton, NeSideDrawer, NeTextInput } from '@nethesis/vue-components'
+import {
+  NeCombobox,
+  NeButton,
+  NeSideDrawer,
+  NeTextInput,
+  NeTooltip
+} from '@nethesis/vue-components'
 import { MessageBag } from '@/lib/validation'
 import type { Policy, Rule } from '@/composables/useMwan'
 import { ubusCall, ValidationError } from '@/lib/standalone/ubus'
@@ -144,7 +150,15 @@ function save() {
         :label="t('standalone.multi_wan.source_port')"
         :placeholder="t('standalone.multi_wan.any')"
         name="source_port"
-      />
+      >
+        <template #tooltip>
+          <NeTooltip>
+            <template #content>
+              {{ t('standalone.multi_wan.ports_tooltip') }}
+            </template>
+          </NeTooltip>
+        </template>
+      </NeTextInput>
       <NeTextInput
         v-model="destinationAddress"
         :disabled="saving"
@@ -161,7 +175,15 @@ function save() {
         :label="t('standalone.multi_wan.destination_port')"
         :placeholder="t('standalone.multi_wan.any')"
         name="destination_port"
-      />
+      >
+        <template #tooltip>
+          <NeTooltip>
+            <template #content>
+              {{ t('standalone.multi_wan.ports_tooltip') }}
+            </template>
+          </NeTooltip>
+        </template>
+      </NeTextInput>
       <hr />
       <div class="flex justify-end gap-4">
         <NeButton :disabled="saving" :kind="'secondary'" @click="close()">

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -383,9 +383,9 @@ export function validatePortRangeForMwan(
   maxRange = 65535
 ): validationOutput {
   let strings: string[]
-  if (value.indexOf(',')) {
+  if (value.includes(',')) {
     strings = value.split(',')
-  } else if (value.indexOf('-')) {
+  } else if (value.includes('-')) {
     strings = value.split('-')
   } else {
     strings = [value]
@@ -393,7 +393,7 @@ export function validatePortRangeForMwan(
   for (const port of strings) {
     const validation = validatePort(port, minRange, maxRange)
     if (!validation.valid) {
-      return { valid: false, errMessage: 'error.invalid_port_range' }
+      return { valid: false, errMessage: 'error.invalid_port_or_port_range' }
     }
   }
   return { valid: true }


### PR DESCRIPTION
This PR attemps to 

- fix a bug in validation of port range with `-`
- add tooltips to port of rule creator and editor


https://github.com/NethServer/nethsecurity/issues/580