### PR TITLE
Refactor: Trim whitespace in input fields

### DIFF
--- a/src/components/standalone/multi-wan/MultiWanGeneralSettings.vue
+++ b/src/components/standalone/multi-wan/MultiWanGeneralSettings.vue
@@ -178,7 +178,7 @@ onMounted(() => {
           <div v-for="index in data.track_ip.keys()" :key="index" class="flex items-center">
             <div class="grow">
               <NeTextInput
-                v-model="data.track_ip[index]"
+                v-model.trim="data.track_ip[index]"
                 :disabled="sending"
                 :invalid-message="messageBag.get(`track_ip.${index}`)?.[0]"
               />

--- a/src/components/standalone/multi-wan/PolicyCreator.vue
+++ b/src/components/standalone/multi-wan/PolicyCreator.vue
@@ -150,7 +150,7 @@ function create() {
     <div v-else class="space-y-8">
       <NeTextInput
         ref="labelElement"
-        v-model="policyForm.label"
+        v-model.trim="policyForm.label"
         :disabled="createDefault"
         :invalid-message="t(messageBag.getFirstI18nKeyFor('name'))"
         :label="t('standalone.multi_wan.label_input_label')"

--- a/src/components/standalone/multi-wan/PolicyEditor.vue
+++ b/src/components/standalone/multi-wan/PolicyEditor.vue
@@ -134,7 +134,7 @@ function submit() {
     <div v-else class="space-y-8">
       <NeTextInput
         ref="labelElement"
-        v-model="policyForm.label"
+        v-model.trim="policyForm.label"
         disabled
         :invalid-message="messageBag.getFirstI18nKeyFor('name')"
         :label="t('standalone.multi_wan.label_input_label')"

--- a/src/components/standalone/multi-wan/RuleCreator.vue
+++ b/src/components/standalone/multi-wan/RuleCreator.vue
@@ -89,7 +89,7 @@ function save() {
   >
     <div class="space-y-8">
       <NeTextInput
-        v-model="name"
+        v-model.trim="name"
         :disabled="saving"
         :invalid-message="t(validationErrors.getFirstI18nKeyFor('name'))"
         :label="t('standalone.multi_wan.rule_name')"
@@ -127,7 +127,7 @@ function save() {
         :optionalLabel="t('common.optional')"
       />
       <NeTextInput
-        v-model="sourceAddress"
+        v-model.trim="sourceAddress"
         :disabled="saving"
         :invalid-message="t(validationErrors.getFirstI18nKeyFor('source_address'))"
         :label="t('standalone.multi_wan.source_address')"
@@ -136,7 +136,7 @@ function save() {
       />
       <NeTextInput
         v-if="protocol == 'tcp' || protocol == 'udp'"
-        v-model="sourcePort"
+        v-model.trim="sourcePort"
         :disabled="saving"
         :invalid-message="t(validationErrors.getFirstI18nKeyFor('source_port'))"
         :label="t('standalone.multi_wan.source_port')"
@@ -144,7 +144,7 @@ function save() {
         name="source_port"
       />
       <NeTextInput
-        v-model="destinationAddress"
+        v-model.trim="destinationAddress"
         :disabled="saving"
         :invalid-message="t(validationErrors.getFirstI18nKeyFor('destination_address'))"
         :label="t('standalone.multi_wan.destination_address')"
@@ -153,7 +153,7 @@ function save() {
       />
       <NeTextInput
         v-if="protocol == 'tcp' || protocol == 'udp'"
-        v-model="destinationPort"
+        v-model.trim="destinationPort"
         :disabled="saving"
         :invalid-message="t(validationErrors.getFirstI18nKeyFor('destination_port'))"
         :label="t('standalone.multi_wan.destination_port')"

--- a/src/components/standalone/multi-wan/RuleEditor.vue
+++ b/src/components/standalone/multi-wan/RuleEditor.vue
@@ -91,7 +91,7 @@ function save() {
   >
     <div class="space-y-8">
       <NeTextInput
-        v-model="name"
+        v-model.trim="name"
         disabled
         :invalid-message="t(validationErrors.getFirstI18nKeyFor('name'))"
         :label="t('standalone.multi_wan.rule_name')"
@@ -129,7 +129,7 @@ function save() {
         :optionalLabel="t('common.optional')"
       />
       <NeTextInput
-        v-model="sourceAddress"
+        v-model.trim="sourceAddress"
         :disabled="saving"
         :invalid-message="t(validationErrors.getFirstI18nKeyFor('source_address'))"
         :label="t('standalone.multi_wan.source_address')"
@@ -138,7 +138,7 @@ function save() {
       />
       <NeTextInput
         v-if="protocol == 'tcp' || protocol == 'udp'"
-        v-model="sourcePort"
+        v-model.trim="sourcePort"
         :disabled="saving"
         :invalid-message="t(validationErrors.getFirstI18nKeyFor('source_port'))"
         :label="t('standalone.multi_wan.source_port')"
@@ -146,7 +146,7 @@ function save() {
         name="source_port"
       />
       <NeTextInput
-        v-model="destinationAddress"
+        v-model.trim="destinationAddress"
         :disabled="saving"
         :invalid-message="t(validationErrors.getFirstI18nKeyFor('destination_address'))"
         :label="t('standalone.multi_wan.destination_address')"
@@ -155,7 +155,7 @@ function save() {
       />
       <NeTextInput
         v-if="protocol == 'tcp' || protocol == 'udp'"
-        v-model="destinationPort"
+        v-model.trim="destinationPort"
         :disabled="saving"
         :invalid-message="t(validationErrors.getFirstI18nKeyFor('destination_port'))"
         :label="t('standalone.multi_wan.destination_port')"


### PR DESCRIPTION
This pull request refactors multiple components to trim whitespace in input fields.

The affected components are RuleEditor.vue, RuleCreator.vue, PolicyEditor.vue, PolicyCreator.vue, and MultiWanGeneralSettings.vue.

The whitespace trimming is done using the v-model.trim directive.

This improves the user experience by automatically removing leading and trailing whitespace from input values.

https://github.com/NethServer/nethsecurity/issues/580