### PR TITLE
fix: always show passhprase field while restoring

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -565,7 +565,7 @@
         "restore_in_progress": "Restoring backup and rebooting the unit, please wait\n",
         "restore_backup": "Restore backup",
         "passphrase": "Passphrase",
-        "passphrase_helper": "Enter the passphrase used to encrypt the backup; if the passphrase is incorrect, it will not be possible to restore the backup.",
+        "passphrase_helper": "Enter the passphrase used to encrypt the backup, or leave empty if the backup is not encrypted. If the passphrase is incorrect, the backup cannot be restored.",
         "source": "Backup source",
         "backup": "Backup",
         "from_backup": "From last backups",

--- a/src/components/standalone/backup_and_restore/RestoreContent.vue
+++ b/src/components/standalone/backup_and_restore/RestoreContent.vue
@@ -141,19 +141,6 @@ function validateRestore(): boolean {
   let isValidationOk = true
   let isFocusInput = false
 
-  if (isSetPassphrase.value) {
-    let { valid, errMessage } = validateRequired(formRestore.value.passphrase)
-    if (!valid) {
-      errorRestore.value.passphrase = t(errMessage as string)
-      isValidationOk = false
-    }
-  }
-
-  if (!isValidationOk) {
-    focusElement(passphraseRef)
-    isFocusInput = true
-  }
-
   if (typeRestore.value === 'upload_file') {
     let { valid, errMessage } = validateRequired(
       formRestore?.value?.file ? formRestore.value.file : ''
@@ -342,23 +329,23 @@ function setRestoreTimer() {
             ref="fileRef"
           />
         </template>
-        <template v-if="isSetPassphrase">
-          <NeTextInput
-            v-model="formRestore.passphrase"
-            :invalid-message="errorRestore.passphrase"
-            :label="t('standalone.backup_and_restore.restore.passphrase')"
-            isPassword
-            ref="passphraseRef"
-          >
-            <template #tooltip>
-              <NeTooltip>
-                <template #content>
-                  {{ t('standalone.backup_and_restore.restore.passphrase_helper') }}
-                </template>
-              </NeTooltip>
-            </template>
-          </NeTextInput>
-        </template>
+        <NeTextInput
+          v-model="formRestore.passphrase"
+          :invalid-message="errorRestore.passphrase"
+          :label="t('standalone.backup_and_restore.restore.passphrase')"
+          isPassword
+          optional
+          :optionalLabel="t('common.optional')"
+          ref="passphraseRef"
+        >
+          <template #tooltip>
+            <NeTooltip>
+              <template #content>
+                {{ t('standalone.backup_and_restore.restore.passphrase_helper') }}
+              </template>
+            </NeTooltip>
+          </template>
+        </NeTextInput>
         <hr />
         <NeInlineNotification
           v-if="errorRestoreBackup.notificationTitle"


### PR DESCRIPTION
Always show passhprase field while restoring: the user might upload a file encrypted or not, it's not known a priori.