### PR TITLE
Refactor backup restoration validation handling and add new translations

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -330,7 +330,9 @@
     "cannot_remove_unit": "Cannot remove unit",
     "cannot_scan_network": "Cannot scan network",
     "cannot_retrieve_vpn_networks": "Cannot retrieve VPN networks",
-    "length_12_max": "Maximum 12 characters allowed"
+    "length_12_max": "Maximum 12 characters allowed",
+    "backup_passphrase_decryption_failed": "Decryption failed: passphrase may be incorrect",
+    "backup_passphrase_restore_failed": "Restore failed: passphrase may be required or backup file may be invalid"
   },
   "ne_text_input": {
     "show_password": "Show password",


### PR DESCRIPTION
This pull request includes a refactoring of the backup restoration process to handle validation errors more effectively. Additionally, new translations have been added to improve error messaging during backup restoration.

A function to clean the form when cancel or close has been added

REFs:
- https://github.com/NethServer/nethsecurity/pull/586
- https://github.com/NethServer/nethsecurity/issues/587

![Capture d’écran du 2024-06-13 12-32-43](https://github.com/NethServer/nethsecurity-ui/assets/3164851/316f4119-ca3e-48bd-bb59-f1934c9fb4ba)

![Capture d’écran du 2024-06-13 12-32-35](https://github.com/NethServer/nethsecurity-ui/assets/3164851/1781432f-1b97-488e-b09d-32771dab234e)
