### PR TITLE
Add sticky toggle to multi-WAN rule creation and editing

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -330,7 +330,8 @@
     "cannot_remove_unit": "Cannot remove unit",
     "cannot_scan_network": "Cannot scan network",
     "cannot_retrieve_vpn_networks": "Cannot retrieve VPN networks",
-    "length_12_max": "Maximum 12 characters allowed"
+    "length_12_max": "Maximum 12 characters allowed",
+    "sticky_not_valid": "Invalid sticky value"
   },
   "ne_text_input": {
     "show_password": "Show password",
@@ -884,6 +885,8 @@
       "destination_port": "Destination Port",
       "ports_tooltip": "Enter a single port, multiple ports separated by a comma (e.g. '8686, 9090') or port ranges (e.g. '5500-5600')",
       "protocol": "Protocol",
+      "sticky": "Sticky",
+      "sticky_tooltip": "Allow traffic from the same source IP address to use same WAN interface as prior session (default timeout: 10 minutes).",
       "edit_rule": "Edit {name} rule",
       "priority": "Priority {n}",
       "rules": "Rules",

--- a/src/components/standalone/multi-wan/RuleCreator.vue
+++ b/src/components/standalone/multi-wan/RuleCreator.vue
@@ -9,7 +9,8 @@ import {
   NeButton,
   NeSideDrawer,
   NeTextInput,
-  NeTooltip
+  NeTooltip,
+  NeToggle
 } from '@nethesis/vue-components'
 import { ref, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -40,6 +41,7 @@ const {
   sourcePort,
   destinationAddress,
   destinationPort,
+  sticky,
   validationErrors,
   isValid
 } = useRuleForm(toRef(() => props.policies))
@@ -72,7 +74,8 @@ function save() {
       source_address: sourceAddress.value,
       source_port: sourcePort.value,
       destination_address: destinationAddress.value,
-      destination_port: destinationPort.value
+      destination_port: destinationPort.value,
+      sticky: sticky.value
     })
       .then(() => emit('success'))
       .catch((reason: Error) => {
@@ -182,6 +185,19 @@ function save() {
           </NeTooltip>
         </template>
       </NeTextInput>
+      <NeToggle
+        v-model="sticky"
+        :topLabel="t('standalone.multi_wan.sticky')"
+        :label="sticky ? t('common.enabled') : t('common.disabled')"
+      >
+        <template #topTooltip>
+          <NeTooltip placement="top-start">
+            <template #content>
+              {{ t('standalone.multi_wan.sticky_tooltip') }}
+            </template>
+          </NeTooltip>
+        </template>
+      </NeToggle>
       <hr />
       <div class="flex justify-end gap-4">
         <NeButton :disabled="saving" :kind="'secondary'" @click="close()">

--- a/src/components/standalone/multi-wan/RuleEditor.vue
+++ b/src/components/standalone/multi-wan/RuleEditor.vue
@@ -11,7 +11,8 @@ import {
   NeButton,
   NeSideDrawer,
   NeTextInput,
-  NeTooltip
+  NeTooltip,
+  NeToggle
 } from '@nethesis/vue-components'
 import { MessageBag } from '@/lib/validation'
 import type { Policy, Rule } from '@/composables/useMwan'
@@ -36,6 +37,7 @@ const {
   sourcePort,
   destinationAddress,
   destinationPort,
+  sticky,
   validationErrors,
   isValid
 } = useRuleForm(
@@ -74,7 +76,8 @@ function save() {
       source_address: sourceAddress.value,
       source_port: sourcePort.value,
       destination_address: destinationAddress.value,
-      destination_port: destinationPort.value
+      destination_port: destinationPort.value,
+      sticky: sticky.value
     })
       .then(() => emit('success'))
       .catch((reason: Error) => {
@@ -184,6 +187,19 @@ function save() {
           </NeTooltip>
         </template>
       </NeTextInput>
+      <NeToggle
+        v-model="sticky"
+        :topLabel="t('standalone.multi_wan.sticky')"
+        :label="sticky ? t('common.enabled') : t('common.disabled')"
+      >
+        <template #topTooltip>
+          <NeTooltip placement="top-start">
+            <template #content>
+              {{ t('standalone.multi_wan.sticky_tooltip') }}
+            </template>
+          </NeTooltip>
+        </template>
+      </NeToggle>
       <hr />
       <div class="flex justify-end gap-4">
         <NeButton :disabled="saving" :kind="'secondary'" @click="close()">

--- a/src/composables/useMwan.ts
+++ b/src/composables/useMwan.ts
@@ -34,6 +34,7 @@ export interface Rule {
   source_port?: string
   destination_address?: string
   destination_port?: string
+  sticky: boolean
 }
 
 interface ApiResponse<T> {

--- a/src/composables/useRuleForm.ts
+++ b/src/composables/useRuleForm.ts
@@ -66,6 +66,7 @@ export function useRuleForm(policies: Ref<Policy[]>, rule?: Ref<Rule | undefined
         sourcePort.value = rule.value.source_port ?? ''
         destinationAddress.value = rule.value.destination_address ?? ''
         destinationPort.value = rule.value.destination_port ?? ''
+        sticky.value = rule.value.sticky
       }
     }
   )
@@ -77,6 +78,7 @@ export function useRuleForm(policies: Ref<Policy[]>, rule?: Ref<Rule | undefined
   const sourcePort = ref('')
   const destinationAddress = ref('')
   const destinationPort = ref('')
+  const sticky = ref(false)
 
   const validationErrors = ref(new MessageBag())
 
@@ -131,6 +133,7 @@ export function useRuleForm(policies: Ref<Policy[]>, rule?: Ref<Rule | undefined
     destinationAddress,
     destinationPort,
     validationErrors,
+    sticky,
     isValid
   }
 }


### PR DESCRIPTION
This pull request refactors the multi-wan policy creator and editor to add a sticky connection feature. 

It also includes form validation for the sticky connection feature. 

The changes include modifications to the RuleCreator.vue and RuleEditor.vue components, as well as updates to the useMwan.ts and useRuleForm.ts files.

Prerequisites: 
- ns-api tag after https://github.com/NethServer/nethsecurity/pull/582

https://github.com/NethServer/nethsecurity/issues/581


![image](https://github.com/NethServer/nethsecurity-ui/assets/3164851/46b4e133-b069-4926-a96e-b6dc9fa46ab9)
![image](https://github.com/NethServer/nethsecurity-ui/assets/3164851/a7ed60b0-7721-4ea8-812a-94f28ba75af2)
![image](https://github.com/NethServer/nethsecurity-ui/assets/3164851/46e1e619-7e54-490a-b20f-0383ca8ab13b)