### PR TITLE
Add validation messages for backup restore

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -332,7 +332,8 @@
     "cannot_retrieve_vpn_networks": "Cannot retrieve VPN networks",
     "length_12_max": "Maximum 12 characters allowed",
     "backup_passphrase_decryption_failed": "Decryption failed: passphrase may be incorrect",
-    "backup_passphrase_restore_failed": "Restore failed: passphrase may be required or backup file may be invalid",
+    "backup_passphrase_restore_failed": "Restore failed: backup file may be invalid",
+    "backup_passphrase_passphrase_required": "Decryption failed: passphrase is required",
     "sticky_not_valid": "Invalid sticky value"
   },
   "ne_text_input": {


### PR DESCRIPTION
This pull request adds validation messages for the backup restore feature. It includes changes to the translation file to add new error messages for decryption failure and invalid backup files.

https://github.com/NethServer/nethsecurity/issues/587