### PR TITLE
fix: i18n format of user bind dn tooltip message

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -1665,7 +1665,7 @@
       "bind_password": "Bind password",
       "bind_password_tooltip": "Password for Bind DN, used to authenticate the connection to the LDAP server",
       "user_bind_dn": "Custom user bind DN",
-      "user_bind_dn_tooltip": "Distinguished Name (DN) used to bind to the LDAP directory. This overrides the calculated user bind DN. Use it when authenticating against an Active Directory. It can contain a '%u' variable that will be expanded to the user name. Example: '%u@secrexample.com', 'SECRETEXAMPLE\\%u'",
+      "user_bind_dn_tooltip": "Distinguished Name (DN) used to bind to the LDAP directory. This overrides the calculated user bind DN. Use it when authenticating against an Active Directory. It can contain a '%u' variable that will be expanded to the user name. Example: '%u{'@'}secretexample.com', 'SECRETEXAMPLE\\%u'",
       "user_attribute": "User attribute field",
       "user_attribute_tooltip": "LDAP attribute that corresponds to the user's identity. This attribute is used to uniquely identify users within the LDAP directory. Example: 'uid' for OpenLDAP or 'cn' for Active Directory",
       "starttls": "StartTLS",


### PR DESCRIPTION
Add remote user database: fix i18n message format of **Custom user bind DN** field tooltip. The `@` character is special and requires this format: `{'@'}`