### PR TITLE
fix: handle domain_set_conflict in fw rules

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -344,7 +344,8 @@
     "cannot_retrieve_domain_sets": "Cannot retrieve domain sets",
     "loop_detected": "Loop detected: a host set cannot contain itself",
     "cannot_retrieve_usages": "Cannot retrieve usages",
-    "invalid_name": "Invalid name"
+    "invalid_name": "Invalid name",
+    "domain_set_conflict": "Domain set cannot be used as both source and destination"
   },
   "ne_text_input": {
     "show_password": "Show password",

--- a/src/components/standalone/firewall/rules/CreateOrEditFirewallRuleDrawer.vue
+++ b/src/components/standalone/firewall/rules/CreateOrEditFirewallRuleDrawer.vue
@@ -619,7 +619,7 @@ function validate() {
 
       const destinationObjectValidation = validateRequired(destinationAddressObject.value)
       if (!destinationObjectValidation.valid) {
-        errorBag.value.set('ns_dst', [t(String(destinationObjectValidation.errMessage))])
+        errorBag.value.set('ns_dst', [destinationObjectValidation.errMessage as string])
         isValidationOk = false
         focusElement(destinationAddressObjectRef)
       }
@@ -963,7 +963,7 @@ async function saveRule() {
             :placeholder="
               loading.listObjectSuggestions ? t('common.loading') : t('ne_combobox.choose')
             "
-            :invalidMessage="errorBag.getFirstFor('ns_dst')"
+            :invalidMessage="t(errorBag.getFirstI18nKeyFor('ns_dst'))"
             :optionalLabel="t('common.optional')"
             :noResultsLabel="t('ne_combobox.no_results')"
             :limitedOptionsLabel="t('ne_combobox.limited_options_label')"


### PR DESCRIPTION
Firewall rules: show "Domain set cannot be used as both source and destination" if user selects the same domain set as source and destination of the rule.