### PR TITLE
fix(i18n): change label for blocklist subscription

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -1397,7 +1397,7 @@
       "threat_shield_status_description": "When enabled, Threat shield blocks all new connections to and from malicious IP addresses. Blocked connections are logged with the tag 'banIP/{'<'}direction{'>'}-{'<'}zone{'>'}/{'<'}action{'>'}/{'<'}blocklist{'>'}'.",
       "status": "Status",
       "blocklist_description": "Threat shield keeps you safe by blocking attacks from known malicious IP addresses. These addresses are compiled into blocklists, each with a clear name that tells you its purpose and who maintains it. The confidence score is a value from 1 to 10 that indicates the quality of the list. A higher number means a lower chance of false positives. This score is not available for 'Community' lists.",
-      "blocklist_subscription_description": "Nethesis and Yoroi blocklists are available only if the machine has a valid Enterprise subscription that includes Threat shield service.",
+      "blocklist_subscription_description": "Nethesis and Yoroi blocklists are available only if {product} has a valid subscription that includes Threat shield service.",
       "threat_shield_enabled": "Threat shield enabled",
       "threat_shield_disabled": "Threat shield disabled",
       "name": "Name",

--- a/public/i18n/it/translation.json
+++ b/public/i18n/it/translation.json
@@ -1681,7 +1681,7 @@
     },
     "threat_shield": {
       "status": "Stato",
-      "blocklist_subscription_description": "Le blocklist Nethesis e Yoroi sono disponibili solo se le macchine hanno una valida subscription Enterprise che include il servizio Threat shield.",
+      "blocklist_subscription_description": "Le blocklist Nethesis e Yoroi sono disponibili solo se {product} ha una subscription valida che include il servizio Threat shield.",
       "threat_shield_disabled": "Threat shield disabilitato",
       "type": "Tipo",
       "confidence": "Confidenza",


### PR DESCRIPTION
Blocklists are now available both for Enterprise and Community subscriptions