### PR TITLE
fix: revert unwanted change in ovpn dhcp custom options

### DIFF
--- a/src/components/standalone/openvpn_rw/CreateOrEditRWServerDrawer.vue
+++ b/src/components/standalone/openvpn_rw/CreateOrEditRWServerDrawer.vue
@@ -624,7 +624,7 @@ watch(
         <NeMultiTextInput
           v-model="customOptions"
           :title="t('standalone.openvpn_rw.custom_dhcp_options')"
-          :use-key-input="false"
+          :use-key-input="true"
           key-input-type="combobox"
           :add-item-label="t('standalone.openvpn_rw.add_option')"
           :optional="true"


### PR DESCRIPTION
The value of a `NeMultiTextInput` prop in the drawer "Create OpenVPN Road Warrior server" was previously changed by mistake.
In this  PR we revert it to its correct value.