### PR TITLE
fix: remove tooltip from openvpn rw field

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -1569,8 +1569,7 @@
       "dynamic_range_ip": "Dynamic range IP",
       "dynamic_range_ip_message": "You can reserve IP addresses to OpenVPN accounts outside the following range.",
       "dynamic_range_ip_start": "Dynamic range IP start",
-      "dynamic_range_ip_end": "Dynamic range IP end",
-      "dynamic_range_ip_start_tooltip": "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      "dynamic_range_ip_end": "Dynamic range IP end"
     },
     "openvpn_tunnel": {
       "title": "OpenVPN tunnel",

--- a/src/components/standalone/openvpn_rw/CreateOrEditRWServerDrawer.vue
+++ b/src/components/standalone/openvpn_rw/CreateOrEditRWServerDrawer.vue
@@ -614,15 +614,7 @@ watch(
           :label="t('standalone.openvpn_rw.dynamic_range_ip_start')"
           :invalid-message="t(validationErrorBag.getFirstI18nKeyFor('ifconfig_pool_start'))"
           ref="dynamicRangeIpStartRef"
-        >
-          <template #tooltip>
-            <NeTooltip>
-              <template #content>
-                {{ t('standalone.openvpn_rw.dynamic_range_ip_start_tooltip') }}
-              </template>
-            </NeTooltip>
-          </template>
-        </NeTextInput>
+        />
         <NeTextInput
           v-model="dynamicRangeIpEnd"
           :label="t('standalone.openvpn_rw.dynamic_range_ip_end')"


### PR DESCRIPTION
Remove tooltip from **Dynamic range IP start** field in **Create OpenVPN Road Warrior server** drawer.