### PR TITLE
fix: show Account menu on top of toast notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@nethesis/nethesis-brands-svg-icons": "github:nethesis/Font-Awesome#ns-brands",
         "@nethesis/nethesis-light-svg-icons": "github:nethesis/Font-Awesome#ns-light",
         "@nethesis/nethesis-solid-svg-icons": "github:nethesis/Font-Awesome#ns-solid",
-        "@nethesis/vue-components": "^1.4.0",
+        "@nethesis/vue-components": "^1.5.0",
         "@types/lodash-es": "^4.17.12",
         "@vuepic/vue-datepicker": "^7.2.2",
         "@vueuse/core": "^10.5.0",
@@ -1331,9 +1331,9 @@
       }
     },
     "node_modules/@nethesis/vue-components": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@nethesis/vue-components/-/vue-components-1.4.0.tgz",
-      "integrity": "sha512-fkXr6NJoxxJKXLEdZukP4NfZEDsRkU3bFSTPDbJFyHHRLvkvQBX4PnoZKhQ5cLfLRmug9KEqZBq2vRXWdrhsTQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@nethesis/vue-components/-/vue-components-1.5.0.tgz",
+      "integrity": "sha512-AdLSSGO1zxWMMt2AoPgZIdjVkqt+UFachjDBXmihYzz6pCHCSTjBwdY6DFpBzwja9ZsXvDCaHlVIPZD4kCZMJw==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
         "@fortawesome/free-solid-svg-icons": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@nethesis/nethesis-brands-svg-icons": "github:nethesis/Font-Awesome#ns-brands",
     "@nethesis/nethesis-light-svg-icons": "github:nethesis/Font-Awesome#ns-light",
     "@nethesis/nethesis-solid-svg-icons": "github:nethesis/Font-Awesome#ns-solid",
-    "@nethesis/vue-components": "^1.4.0",
+    "@nethesis/vue-components": "^1.5.0",
     "@types/lodash-es": "^4.17.12",
     "@vuepic/vue-datepicker": "^7.2.2",
     "@vueuse/core": "^10.5.0",

--- a/src/components/controller/ControllerTopBar.vue
+++ b/src/components/controller/ControllerTopBar.vue
@@ -152,6 +152,7 @@ function openNotificationsDrawer() {
               :items="accountMenuOptions"
               :alignToRight="true"
               :openMenuAriaLabel="t('common.shell.open_user_menu')"
+              menuClasses="!z-[150]"
             >
               <template #button>
                 <button type="button" :class="['-m-2.5 flex p-2.5', topBarButtonsColorClasses]">

--- a/src/components/standalone/StandaloneTopBar.vue
+++ b/src/components/standalone/StandaloneTopBar.vue
@@ -228,6 +228,7 @@ function openNotificationsDrawer() {
               :items="accountMenuOptions"
               :alignToRight="true"
               :openMenuAriaLabel="t('common.shell.open_user_menu')"
+              menuClasses="!z-[150]"
             >
               <template #button>
                 <button type="button" :class="['-m-2.5 flex p-2.5', topBarButtonsColorClasses]">


### PR DESCRIPTION
Use the new `menuClasses` prop of `NeDropdown` component to show Account menu on top of toast notifications

See:
- https://github.com/NethServer/nethsecurity/issues/821
- https://github.com/nethesis/vue-components/pull/72