### PR TITLE
Add option to download all user configurations in OpenVPN

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -1624,7 +1624,8 @@
       "dynamic_range_ip": "Dynamic range IP",
       "dynamic_range_ip_message": "You can reserve IP addresses to OpenVPN accounts outside the following range.",
       "dynamic_range_ip_start": "Dynamic range IP start",
-      "dynamic_range_ip_end": "Dynamic range IP end"
+      "dynamic_range_ip_end": "Dynamic range IP end",
+      "download_all_configs": "Download all configurations"
     },
     "openvpn_tunnel": {
       "title": "OpenVPN tunnel",

--- a/src/components/standalone/openvpn_rw/RWAccountsManager.vue
+++ b/src/components/standalone/openvpn_rw/RWAccountsManager.vue
@@ -27,6 +27,7 @@ import CreateOrEditRWAccountDrawer from './CreateOrEditRWAccountDrawer.vue'
 import RenewCertificateDrawer from './RenewCertificateDrawer.vue'
 import { useNotificationsStore } from '@/stores/notifications'
 import { downloadFile, deleteFile } from '@/lib/standalone/fileUpload'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 type ConnectionFilter = 'all' | 'connected' | 'not_connected'
 type ExpirationFilter = 'all' | 'expired' | 'not_expired'


### PR DESCRIPTION
This pull request adds a new feature to the OpenVPN module. It introduces the ability to download all user configurations at once. The "Download all user configurations" option is now available in the OpenVPN accounts table. This feature improves user experience and simplifies the process of managing user configurations.

https://github.com/orgs/NethServer/projects/10/views/2?pane=issue&itemId=80692610

![image](https://github.com/user-attachments/assets/8c686b8e-86d9-46c9-aefc-863abe744c21)

