### PR TITLE
fix(mwan): add length validation for name

### DIFF
--- a/src/components/standalone/multi-wan/RuleCreator.vue
+++ b/src/components/standalone/multi-wan/RuleCreator.vue
@@ -152,7 +152,7 @@ function save() {
       <NeTextInput
         v-model.trim="name"
         :disabled="saving"
-        :invalid-message="t(validationErrors.getFirstI18nKeyFor('name'))"
+        :invalid-message="validationErrors.getFirstFor('name')"
         :label="t('standalone.multi_wan.rule_name')"
         :placeholder="t('standalone.multi_wan.rule_name')"
         name="rule_name"

--- a/src/composables/useRuleForm.ts
+++ b/src/composables/useRuleForm.ts
@@ -10,7 +10,8 @@ import {
   MessageBag,
   validateIp4OrCidr,
   validatePortRangeForMwan,
-  validateRequired
+  validateRequired,
+  validateUciName
 } from '@/lib/validation'
 import { type ObjectReference, useObjects } from '@/composables/useObjects'
 import { ubusCall } from '@/lib/standalone/ubus'
@@ -170,6 +171,10 @@ export function useRuleForm(policies: Ref<Policy[]>, rule?: Ref<Rule | undefined
     validationCheck = validateRequired(policy.value)
     if (!validationCheck.valid) {
       validationErrors.value.set('policy', String(validationCheck.errMessage))
+    }
+    const { valid, errMessage, i18Params } = validateUciName(name.value, 12)
+    if (!valid) {
+      validationErrors.value.set('name', t(errMessage as string, i18Params as any))
     }
     if (sourceAddress.value != '') {
       validationCheck = validateIp4OrCidr(sourceAddress.value)


### PR DESCRIPTION
This pull request adds a length validation for the name rule in the `useRuleForm.ts` file. The validation ensures that the name is not more than 12 characters long. This validation is implemented in the `validateLengthNotMore12` function in the `validation.ts` file.

https://github.com/NethServer/nethsecurity/issues/835