### PR TITLE
fix: improve new release available warning

### DIFF
--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -658,7 +658,7 @@
       "installed_release": "Installed release: {release}",
       "update_with_image_file": "Update with image file",
       "all_updates_installed_notification": "All updates are installed",
-      "latest_release": "Latest release",
+      "new_release_available": "New release available",
       "bug_security_fixes_to_update": "Bug and security fixes to update",
       "component_update_details": "{versionFrom} to {versionTo}",
       "update_in_progress_message": "Updating the unit, please wait...",

--- a/src/components/NotificationDrawer.vue
+++ b/src/components/NotificationDrawer.vue
@@ -29,7 +29,7 @@ function closeDrawer() {
     <NeEmptyState
       v-if="isEmpty(notificationsStore.notifications)"
       :title="t('notifications.no_notification')"
-      :icon="['far', 'bell']"
+      :icon="['fas', 'bell']"
     />
     <!-- notifications -->
     <div v-else class="flex w-full flex-col items-center space-y-4 sm:items-end">

--- a/src/components/standalone/dashboard/SystemInfoCard.vue
+++ b/src/components/standalone/dashboard/SystemInfoCard.vue
@@ -203,9 +203,22 @@ async function getUpdatesStatus() {
         <div class="inline-flex items-center gap-2">
           <span>{{ systemInfo?.version?.release || '-' }}</span>
           <NeSpinner v-if="loading.getUpdatesStatus" size="4" />
-          <NeLink v-if="isUpdateAvailable && !isUpdateScheduled" @click="goToUpdates">
-            {{ t('standalone.update.update') }}
-          </NeLink>
+          <!-- warning for image update available -->
+          <NeTooltip v-if="isUpdateAvailable && !isUpdateScheduled" class="leading-none">
+            <template #trigger>
+              <font-awesome-icon
+                :icon="['fas', 'warning']"
+                class="h-4 w-4 text-amber-700 dark:text-amber-500"
+                aria-hidden="true"
+              />
+            </template>
+            <template #content>
+              {{ t('standalone.update.new_release_available') }}.
+              <NeLink invertedTheme @click="goToUpdates">
+                {{ t('common.go_to_page', { page: t('standalone.update.title') }) }}
+              </NeLink>
+            </template>
+          </NeTooltip>
         </div>
       </div>
       <div class="py-3">

--- a/src/views/standalone/system/UpdateView.vue
+++ b/src/views/standalone/system/UpdateView.vue
@@ -324,11 +324,12 @@ onMounted(() => {
           systemUpdateData?.lastVersion &&
           systemUpdateData.lastVersion != systemUpdateData?.currentVersion
         "
-        :title="t('standalone.update.latest_release')"
+        :title="t('standalone.update.new_release_available')"
         :description="systemUpdateData?.lastVersion"
       />
       <div class="mt-4">
         <NeButton
+          kind="primary"
           class="mb-2 mr-4"
           v-if="
             systemUpdateData?.lastVersion &&


### PR DESCRIPTION
Improve the visibility of new release updates by replacing the current subtle blue "Update" link with a more prominent yellow triangle icon.

Other changes:
- Minor fixes in **Updates** page
- Fix style of icon in empty state of notification drawer

![image](https://github.com/user-attachments/assets/a570a16b-61b1-4d17-933b-af283896e357)

![image](https://github.com/user-attachments/assets/eb12256a-7d3d-4a3e-b57b-8d1a315729a1)
