### PR TITLE
fix(dhcp): ensure MAC is saved with columns syntax

### DIFF
--- a/src/components/standalone/dns_dhcp/CreateOrEditStaticLeaseDrawer.vue
+++ b/src/components/standalone/dns_dhcp/CreateOrEditStaticLeaseDrawer.vue
@@ -121,7 +121,8 @@ async function createOrEditStaticLease() {
         hostname: hostname.value,
         ipaddr: ipAddress.value,
         description: reservationName.value,
-        macaddr: macAddress.value
+        // ensure MAC address uses colons instead of dashes
+        macaddr: macAddress.value.replace(/-/g, ':')
       }
 
       if (isEditing) {


### PR DESCRIPTION
Ensure that when creating a DHCP static lease, the MAC address is saved using colon syntax, not dash syntax.

Ref:
- https://github.com/NethServer/nethsecurity/issues/847