### PR TITLE
build(lang): removed locale specification, removed warn

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,10 +34,12 @@ app.use(VueTippy, {
 app.use(
   createI18n({
     legacy: false,
-    fallbackLocale: 'en-US',
+    fallbackLocale: 'en',
+    fallbackWarn: false,
+    missingWarn: false,
     messages: {
-      'it-IT': itTranslation,
-      'en-US': enTranslation
+      it: itTranslation,
+      en: enTranslation
     }
   })
 )


### PR DESCRIPTION
Fixing console warnings in case of falling back in language and missing localization strings
