### PR TITLE
fix: improve domain sets validation

### DIFF
--- a/src/components/standalone/users_objects/CreateOrEditDomainSetDrawer.vue
+++ b/src/components/standalone/users_objects/CreateOrEditDomainSetDrawer.vue
@@ -140,7 +140,7 @@ function validateRecordsRequired() {
     totalChars += record.length
   }
 
-  if (totalChars >= 1024) {
+  if (totalChars >= 960) {
     return {
       valid: false,
       errMessage: 'error.domains_total_chars_exceeded'

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -359,7 +359,7 @@
     "invalid_ipaddr": "One or more records are invalid",
     "empty_domains": "One or more domains are empty",
     "invalid_domains": "One or more domains are invalid",
-    "domains_total_chars_exceeded": "Total characters of all domains must not exceed 1024. Please remove some domains or create a new domain set.",
+    "domains_total_chars_exceeded": "Total characters of all domains must not exceed 960. Please remove some domains or create a new domain set.",
     "cannot_delete_host_set": "Cannot delete host set",
     "cannot_delete_domain_set": "Cannot delete domain set",
     "cannot_retrieve_host_sets": "Cannot retrieve host sets",


### PR DESCRIPTION
Lower to 960 the maximum characters of the domains of a domain set to avoid dnsmask crash

Ref:
- https://github.com/NethServer/nethsecurity/issues/877