### PR TITLE
fix(lang): fixing translation fields under "languages"

### DIFF
--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -1,7 +1,7 @@
 {
   "languages": {
-    "it-IT": "Italian (it-IT)",
-    "en-US": "English (en-US)"
+    "it": "Italian",
+    "en": "English"
   },
   "common": {
     "shell": {


### PR DESCRIPTION
In #417 we've removed the locale specification, forgot to rename translation strings.
