### PR TITLE
fix: remove some validations for domain sets

### DIFF
--- a/src/components/standalone/users_objects/CreateOrEditDomainSetDrawer.vue
+++ b/src/components/standalone/users_objects/CreateOrEditDomainSetDrawer.vue
@@ -125,9 +125,7 @@ function runFieldValidators(
   return validators.every((validator) => validator.valid)
 }
 
-function validateRecordsRequired() {
-  let totalChars = 0
-
+function validateRecords() {
   for (const record of records.value) {
     if (!record) {
       return { valid: false, errMessage: 'error.empty_domains' }
@@ -136,14 +134,6 @@ function validateRecordsRequired() {
     const { valid } = validateDomainName(record)
     if (!valid) {
       return { valid: false, errMessage: 'error.invalid_domains' }
-    }
-    totalChars += record.length
-  }
-
-  if (totalChars >= 960) {
-    return {
-      valid: false,
-      errMessage: 'error.domains_total_chars_exceeded'
     }
   }
   return { valid: true }
@@ -174,7 +164,7 @@ function validate() {
       nameRef
     ],
     // records
-    [[validateRecordsRequired()], 'ipaddr', recordRef]
+    [[validateRecords()], 'domain', recordRef]
   ]
 
   // reset firstErrorRef for focus management
@@ -281,10 +271,10 @@ async function saveDomainSet() {
         />
         <!-- records invalid message -->
         <p
-          v-if="errorBag.getFirstI18nKeyFor('ipaddr')"
+          v-if="errorBag.getFirstI18nKeyFor('domain')"
           :class="'mt-2 text-sm text-rose-700 dark:text-rose-400'"
         >
-          {{ t(errorBag.getFirstI18nKeyFor('ipaddr')) }}
+          {{ t(errorBag.getFirstI18nKeyFor('domain')) }}
         </p>
         <!-- save domain set error notification -->
         <NeInlineNotification

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -359,7 +359,7 @@
     "invalid_ipaddr": "One or more records are invalid",
     "empty_domains": "One or more domains are empty",
     "invalid_domains": "One or more domains are invalid",
-    "domains_total_chars_exceeded": "Total characters of all domains must not exceed 960. Please remove some domains or create a new domain set.",
+    "total_chars_exceeded": "There are too many domains. Please remove some and include them in a new domain set.",
     "cannot_delete_host_set": "Cannot delete host set",
     "cannot_delete_domain_set": "Cannot delete domain set",
     "cannot_retrieve_host_sets": "Cannot retrieve host sets",


### PR DESCRIPTION
The validation of the maximum characters used by a domain set in the dnsmasq configuration file is now handled on the backend.

Refs:

- https://github.com/NethServer/nethsecurity/issues/877
- https://github.com/NethServer/python3-nethsec/pull/73