### PR TITLE
feat(monitoring): show ip addresses of wan ifaces

### DIFF
--- a/src/components/controller/users/UsersTable.vue
+++ b/src/components/controller/users/UsersTable.vue
@@ -21,7 +21,7 @@ import { type ControllerAccount } from '@/stores/controller/accounts'
 import { useLoginStore } from '@/stores/controller/controllerLogin'
 import { ref } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { faCheck, faCircleCheck, faCircleXmark } from '@fortawesome/free-solid-svg-icons'
+import { faCircleCheck, faCircleXmark } from '@fortawesome/free-solid-svg-icons'
 
 const props = defineProps<{
   users: ControllerAccount[]

--- a/src/components/standalone/monitoring/connectivity/WanConnectionsCard.vue
+++ b/src/components/standalone/monitoring/connectivity/WanConnectionsCard.vue
@@ -38,6 +38,7 @@ const { currentPage, paginatedItems } = useItemPagination(() => props.wanConnect
         <NeTableHeadCell>{{ t('standalone.real_time_monitor.interface') }}</NeTableHeadCell>
         <NeTableHeadCell>{{ t('standalone.real_time_monitor.device') }}</NeTableHeadCell>
         <NeTableHeadCell>{{ t('common.status') }}</NeTableHeadCell>
+        <NeTableHeadCell>{{ t('common.ip_address') }}</NeTableHeadCell>
       </NeTableHead>
       <NeTableBody>
         <NeTableRow v-for="(item, index) in paginatedItems" :key="index">
@@ -65,6 +66,12 @@ const { currentPage, paginatedItems } = useItemPagination(() => props.wanConnect
                   : t('standalone.real_time_monitor.offline')
               }}
             </div>
+          </NeTableCell>
+          <NeTableCell :data-label="t('common.ip_address')">
+            <span v-if="item.ip4Addresses.length || item.ip6Addresses.length">
+              {{ (item.ip4Addresses || []).concat(item.ip6Addresses || []).join(', ') }}
+            </span>
+            <span v-else>-</span>
           </NeTableCell>
         </NeTableRow>
       </NeTableBody>

--- a/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
@@ -36,7 +36,6 @@ import { useI18n } from 'vue-i18n'
 import type { ServerTunnel, ClientTunnel } from './TunnelManager.vue'
 import NeMultiTextInput from '../NeMultiTextInput.vue'
 import { ubusCall, ValidationError } from '@/lib/standalone/ubus'
-import { AxiosError } from 'axios'
 
 type TunnelDefaults = {
   secret: string

--- a/src/composables/useNetworkDevices.ts
+++ b/src/composables/useNetworkDevices.ts
@@ -1,0 +1,81 @@
+//  Copyright (C) 2024 Nethesis S.r.l.
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { ubusCall } from '@/lib/standalone/ubus'
+import { getAxiosErrorMessage } from '@nethesis/vue-components'
+import {
+  getName,
+  type DeviceOrIface,
+  type ZoneWithDeviceNames,
+  type ZoneWithDevices
+} from '@/lib/standalone/network'
+import { zonesSorting } from '@/stores/standalone/firewall'
+
+/**
+ * Composable that handles the network devices retrieved from the ns.devices list-devices API
+ */
+export function useNetworkDevices() {
+  const { t } = useI18n()
+
+  const allDevices = ref<DeviceOrIface[]>([])
+  const devicesByZone = ref<ZoneWithDeviceNames[]>([])
+  const loadingListDevices = ref(false)
+  const errorListDevices = ref('')
+  const errorListDevicesDetails = ref('')
+
+  const sortedZonesAndDevices = computed(() => {
+    const zones: ZoneWithDevices[] = []
+    devicesByZone.value.forEach((z: ZoneWithDeviceNames) => {
+      const deviceList: DeviceOrIface[] = []
+      z.devices.forEach((devName: string) => {
+        const devFound = allDevices.value.find((dev) => getName(dev) === devName)
+
+        if (devFound) {
+          deviceList.push(devFound)
+        }
+      })
+      const zone = { name: z.name, devices: deviceList }
+      zones.push(zone)
+    })
+
+    return zones.sort(zonesSorting)
+  })
+
+  async function listDevices() {
+    loadingListDevices.value = true
+    allDevices.value = []
+    devicesByZone.value = []
+    errorListDevices.value = ''
+    errorListDevicesDetails.value = ''
+
+    try {
+      const res = await ubusCall('ns.devices', 'list-devices')
+      const bond_devices = res.data.all_devices
+        .filter((device: DeviceOrIface) => device.name?.startsWith('bond-'))
+        .map((device: DeviceOrIface) => device.name?.slice(5))
+
+      allDevices.value = res.data.all_devices.filter(
+        (device: DeviceOrIface) => !bond_devices.includes(device.name ?? device['.name'])
+      )
+      devicesByZone.value = res.data.devices_by_zone
+    } catch (err: any) {
+      console.error(err)
+      errorListDevices.value = t(getAxiosErrorMessage(err))
+      errorListDevicesDetails.value = err.toString()
+    } finally {
+      loadingListDevices.value = false
+    }
+  }
+
+  return {
+    allDevices,
+    devicesByZone,
+    sortedZonesAndDevices,
+    listDevices,
+    loadingListDevices,
+    errorListDevices,
+    errorListDevicesDetails
+  }
+}

--- a/src/composables/useUciNetworkConfig.ts
+++ b/src/composables/useUciNetworkConfig.ts
@@ -1,0 +1,75 @@
+//  Copyright (C) 2024 Nethesis S.r.l.
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { getUciConfig } from '@/lib/standalone/ubus'
+import { getAxiosErrorMessage } from '@nethesis/vue-components'
+
+export interface UciNetworkConfig {
+  device?: UciNetworkDevice[]
+  interface?: UciNetworkInterface[]
+}
+
+export interface UciNetworkDevice {
+  name?: string
+  '.anonymous'?: boolean
+  '.index'?: number
+  '.name'?: string
+  '.type'?: 'device'
+  ports?: string[]
+  type?: string
+  ipv6?: string
+}
+
+export interface UciNetworkInterface {
+  '.name'?: string
+  '.anonymous'?: boolean
+  '.index'?: number
+  '.type'?: 'interface'
+  device?: string
+  proto?: string
+  ipaddr?: string
+  ip6addr?: string
+  netmask?: string
+  force_link?: string
+  gateway?: string
+  metric?: string
+}
+
+/**
+ * Composable that handles UCI network configuration
+ */
+export function useUciNetworkConfig() {
+  const { t } = useI18n()
+
+  const networkConfig = ref<UciNetworkConfig>()
+  const loadingNetworkConfig = ref(false)
+  const errorNetworkConfig = ref('')
+  const errorNetworkConfigDetails = ref('')
+
+  async function getNetworkConfig() {
+    loadingNetworkConfig.value = true
+    errorNetworkConfig.value = ''
+    errorNetworkConfigDetails.value = ''
+
+    try {
+      networkConfig.value = await getUciConfig('network')
+    } catch (err: any) {
+      console.error(err)
+      networkConfig.value = undefined
+      errorNetworkConfig.value = t(getAxiosErrorMessage(err))
+      errorNetworkConfigDetails.value = err.toString()
+    } finally {
+      loadingNetworkConfig.value = false
+    }
+  }
+
+  return {
+    networkConfig,
+    getNetworkConfig,
+    loadingNetworkConfig,
+    errorNetworkConfig,
+    errorNetworkConfigDetails
+  }
+}

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -56,7 +56,8 @@
     "no_data_available": "No data available",
     "type": "Type",
     "unknown": "Unknown",
-    "confirm": "Confirm"
+    "confirm": "Confirm",
+    "ip_address": "IP address"
   },
   "error": {
     "generic_error": "Something went wrong",

--- a/src/lib/standalone/network.ts
+++ b/src/lib/standalone/network.ts
@@ -3,6 +3,8 @@
 
 import { SpecialZones, type Forwarding, type Zone } from '@/stores/standalone/firewall'
 import { useI18n } from 'vue-i18n'
+import { isEqual, uniqWith } from 'lodash-es'
+import type { UciNetworkConfig } from '@/composables/useUciNetworkConfig'
 
 export interface DeviceOrIface {
   name?: string
@@ -103,14 +105,20 @@ export function getInterfaceDisplayName(deviceOrIface: DeviceOrIface) {
   }
 }
 
-export function getAliasInterface(device: DeviceOrIface, networkConfig: any) {
+export function getAliasInterface(device: DeviceOrIface, networkConfig: UciNetworkConfig) {
+  if (!networkConfig) {
+    return
+  }
+
   const iface = getInterface(device)
 
   if (!iface) {
     return
   }
 
-  return networkConfig.interface.find((ifaceElem: any) => ifaceElem.device === `@${iface['.name']}`)
+  return networkConfig.interface?.find(
+    (ifaceElem: any) => ifaceElem.device === `@${iface['.name']}`
+  )
 }
 
 export function getFirewallZone(iface: any, firewallConfig: any) {
@@ -332,7 +340,7 @@ export function isHotspot(device: DeviceOrIface) {
   return device.hotspot
 }
 
-export function generateDeviceName(devicePrefix: string, networkConfig: any) {
+export function generateDeviceName(devicePrefix: string, networkConfig: UciNetworkConfig) {
   let num = -1
   let nameAlreadyExists = true
   let deviceNameGenerated = ''
@@ -340,7 +348,8 @@ export function generateDeviceName(devicePrefix: string, networkConfig: any) {
   do {
     num++
     deviceNameGenerated = `${devicePrefix}${num}`
-    nameAlreadyExists = networkConfig.device?.find((dev: any) => dev.name === deviceNameGenerated)
+    nameAlreadyExists =
+      networkConfig.device?.some((dev: any) => dev.name === deviceNameGenerated) || false
   } while (nameAlreadyExists)
 
   return deviceNameGenerated
@@ -376,4 +385,102 @@ export function forwardingsToByZone(zone: Zone, forwardings: Forwarding[]): Arra
 // return the forwardings that have input zone as destination
 export function forwardingsFromByZone(zone: Zone, forwardings: Forwarding[]): Array<Forwarding> {
   return forwardings.filter((forwarding: Forwarding) => forwarding.destination == zone.name)
+}
+
+export function getIpv4Addresses(
+  device: DeviceOrIface,
+  networkConfig: UciNetworkConfig | undefined
+) {
+  if (!networkConfig) {
+    return []
+  }
+
+  const ipv4Addresses = []
+  const iface = getInterface(device)
+  const aliasIface = getAliasInterface(device, networkConfig)
+
+  // device ip addresses
+
+  if (device.ipaddrs && device.ipaddrs.length > 0) {
+    for (const ipv4 of device.ipaddrs) {
+      // skip alias addresses
+      if (!aliasIface || !aliasIface.ipaddr || !aliasIface.ipaddr.includes(ipv4.address)) {
+        ipv4Addresses.push(ipv4.address)
+      }
+    }
+  }
+
+  // interface ip address
+
+  if (iface?.ipaddr) {
+    // skip alias addresses
+    if (!aliasIface || !aliasIface.ipaddr || !aliasIface.ipaddr.includes(iface.ipaddr)) {
+      ipv4Addresses.push(iface.ipaddr)
+    }
+  }
+  if (isBond(device) && ipv4Addresses.length > 0) {
+    ipv4Addresses.splice(0, 1)
+  }
+  return uniqWith(ipv4Addresses, isEqual)
+}
+
+export function getIpv6Addresses(
+  device: DeviceOrIface,
+  networkConfig: UciNetworkConfig | undefined
+) {
+  if (!networkConfig) {
+    return []
+  }
+
+  // ensure ipv6 is enabled
+  if (device.ipv6 !== '1') {
+    return []
+  }
+
+  const ipv6Addresses = []
+  const iface = getInterface(device)
+  const aliasIface = getAliasInterface(device, networkConfig)
+
+  // device ip addresses
+
+  if (device.ip6addrs && device.ip6addrs.length > 0) {
+    for (const ipv6 of device.ip6addrs) {
+      // skip alias addresses
+      if (!aliasIface || !aliasIface.ip6addr || !aliasIface.ip6addr.includes(ipv6.address)) {
+        ipv6Addresses.push(ipv6.address)
+      }
+    }
+  }
+
+  // interface ip address
+
+  if (iface?.ip6addr) {
+    let addr = iface.ip6addr
+
+    // ipv6 address is stored inside a one-element array
+    if (addr instanceof Array) {
+      addr = addr[0]
+    }
+
+    // skip alias addresses
+    if (!aliasIface || !aliasIface.ip6addr || !aliasIface.ip6addr.includes(addr)) {
+      ipv6Addresses.push(addr)
+    }
+  }
+  return uniqWith(ipv6Addresses, isEqual)
+}
+
+export function isDeviceUp(device: DeviceOrIface, allDevices: DeviceOrIface[]) {
+  // get parent device if it's a vlan
+  if (isVlan(device)) {
+    const vlanParent = getVlanParent(device, allDevices)
+    return vlanParent?.up
+  }
+  return device?.up
+}
+
+export function getVlanParent(bridgeDevice: DeviceOrIface, allDevices: DeviceOrIface[]) {
+  const parentDevice = bridgeDevice.ifname
+  const deviceFound = allDevices.find((dev) => dev.name === parentDevice)
+  return deviceFound
 }

--- a/src/views/standalone/network/InterfacesAndDevicesView.vue
+++ b/src/views/standalone/network/InterfacesAndDevicesView.vue
@@ -1,5 +1,5 @@
-Copyright (C) 2024 Nethesis S.r.l.
 <!--
+  Copyright (C) 2024 Nethesis S.r.l.
   SPDX-License-Identifier: GPL-3.0-or-later
 -->
 


### PR DESCRIPTION
- Show IP addresses of wan interfaces in **Monitoring > Real time monitor > Connectivity**
- Make **WANs** card visible regardless of multiwan configuration status
- Introduce `useNetworkDevices` and `useUciNetworkConfig` composables
- Minor refactoring of `InterfacesAndDevicesView.vue`
- Move some utility functions to `network.ts`
- Enhance **Connectivity** page layout for very large screens

Ref:
- https://github.com/NethServer/nethsecurity/issues/890