### PR TITLE
fix(monitoring): show wan public ip address

### DIFF
--- a/src/components/standalone/monitoring/connectivity/WanConnectionsCard.vue
+++ b/src/components/standalone/monitoring/connectivity/WanConnectionsCard.vue
@@ -90,7 +90,7 @@ function getQosRule(item: Wan) {
         <NeTableHeadCell>{{ t('standalone.real_time_monitor.interface') }}</NeTableHeadCell>
         <NeTableHeadCell>{{ t('standalone.real_time_monitor.device') }}</NeTableHeadCell>
         <NeTableHeadCell>{{ t('common.status') }}</NeTableHeadCell>
-        <NeTableHeadCell>{{ t('common.ip_address') }}</NeTableHeadCell>
+        <NeTableHeadCell>{{ t('standalone.real_time_monitor.public_ip_address') }}</NeTableHeadCell>
         <NeTableHeadCell>{{ t('standalone.qos.title_short') }}</NeTableHeadCell>
       </NeTableHead>
       <NeTableBody>
@@ -120,9 +120,9 @@ function getQosRule(item: Wan) {
               }}
             </div>
           </NeTableCell>
-          <NeTableCell :data-label="t('common.ip_address')">
-            <span v-if="item.ip4Addresses.length || item.ip6Addresses.length">
-              {{ (item.ip4Addresses || []).concat(item.ip6Addresses || []).join(', ') }}
+          <NeTableCell :data-label="t('standalone.real_time_monitor.public_ip_address')">
+            <span v-if="item.ipAddresses.length">
+              {{ item.ipAddresses.join(', ') }}
             </span>
             <span v-else>-</span>
           </NeTableCell>

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -1962,7 +1962,8 @@
       "ping_host_latency": "Latency to {pingHost}",
       "ping_host_packet_delivery_rate": "Packet delivery rate to {pingHost}",
       "latency_and_packet_delivery_rate": "Latency and packet delivery rate",
-      "no_hosts_configured_for_monitoring": "No hosts configured for monitoring"
+      "no_hosts_configured_for_monitoring": "No hosts configured for monitoring",
+      "public_ip_address": "Public IP address"
     },
     "ping_latency_monitor": {
       "title": "Ping latency monitor",

--- a/src/lib/standalone/network.ts
+++ b/src/lib/standalone/network.ts
@@ -484,3 +484,8 @@ export function getVlanParent(bridgeDevice: DeviceOrIface, allDevices: DeviceOrI
   const deviceFound = allDevices.find((dev) => dev.name === parentDevice)
   return deviceFound
 }
+
+export function isIpv6Enabled(device: DeviceOrIface) {
+  const iface = getInterface(device)
+  return device.ipv6 === '1' || (iface.proto === 'pppoe' && device.ipv6 === 'auto')
+}


### PR DESCRIPTION
- Monitoring: show public IP address(es) of wan interfaces in **Monitoring > Real time monitor > Connectivity**

Ref:
- https://github.com/NethServer/nethsecurity/issues/890