### PR TITLE
fix(controller): fixing missed save of credentials

### DIFF
--- a/src/components/standalone/account/two_fa/TwoFactorAuth.vue
+++ b/src/components/standalone/account/two_fa/TwoFactorAuth.vue
@@ -8,22 +8,24 @@ import { useI18n } from 'vue-i18n'
 import { computed, onMounted, ref } from 'vue'
 import { getTwoFaStatus } from '@/lib/twoFa'
 import {
-  NeInlineNotification,
-  NeSkeleton,
-  NeTooltip,
+  getAxiosErrorMessage,
+  getPreference,
   NeButton,
   NeFormItemLabel,
-  getPreference,
-  savePreference,
-  getAxiosErrorMessage,
-  NeTextArea
+  NeInlineNotification,
+  NeSkeleton,
+  NeTextArea,
+  NeTooltip,
+  savePreference
 } from '@nethesis/vue-components'
 import ConfigureTwoFaDrawer from '@/components/two_fa/ConfigureTwoFaDrawer.vue'
 import RevokeTwoFaModal from '@/components/two_fa/RevokeTwoFaModal.vue'
-import { useLoginStore } from '@/stores/standalone/standaloneLogin'
+import { useLoginStore as useStandaloneLoginStore } from '@/stores/standalone/standaloneLogin'
+import { isStandaloneMode } from '@/lib/config'
+import { useLoginStore as useControllerLoginStore } from '@/stores/controller/controllerLogin'
 
 const { t } = useI18n()
-const loginStore = useLoginStore()
+const loginStore = isStandaloneMode() ? useStandaloneLoginStore() : useControllerLoginStore()
 const isTwoFaEnabled = ref(false)
 const isShownConfigureTwoFaDrawer = ref(false)
 const isShownRevokeTwoFaModal = ref(false)

--- a/src/stores/controller/controllerLogin.ts
+++ b/src/stores/controller/controllerLogin.ts
@@ -71,6 +71,11 @@ export const useLoginStore = defineStore('controllerLogin', () => {
     if (!twoFaActive.value) {
       username.value = user
       role.value = JSON.parse(atob(token.value.split('.')[1])).role
+      saveToStorage('controllerLoginInfo', {
+        username: username.value,
+        token: token.value,
+        tokenRefreshedTime: tokenRefreshedTime.value
+      })
     }
   }
 


### PR DESCRIPTION
Fixing issue arisen with controller 1.2.0.

If no 2FA is configured), the controller doesn't save any info regarding the login. This causes issues due to the UI being unable to login into unit.

A workaround is to activate the 2FA and then logout and log back in.

Ref:
- https://mattermost.nethesis.it/nethesis/pl/rwak4t446pyqmfq1ark1taa5qh
