### PR TITLE
fix(controller): bump ns-api requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nethsecurity-ui",
   "version": "1.16.0",
   "config": {
-    "requiredApiVersion": "~2.0.0"
+    "requiredApiVersion": "~2.1.0"
   },
   "private": true,
   "type": "module",


### PR DESCRIPTION
Due to incoming changes for monitoring, the API must be bumped to `2.1.0`.

Ref:
- https://github.com/NethServer/nethsecurity/pull/971
