### PR TITLE
feat(firewall rule): highlight rules on non-existent zones

### DIFF
--- a/src/components/standalone/firewall/rules/CreateOrEditFirewallRuleDrawer.vue
+++ b/src/components/standalone/firewall/rules/CreateOrEditFirewallRuleDrawer.vue
@@ -720,8 +720,7 @@ async function saveRule() {
       return tag.id
     }),
     log: isLoggingEnabled.value,
-    system_rule: props.currentRule?.system_rule || false,
-    active_zone: props.currentRule?.active_zone || false
+    system_rule: props.currentRule?.system_rule || false
   }
 
   if (isEditingRule.value && props.currentRule) {

--- a/src/components/standalone/firewall/rules/CreateOrEditFirewallRuleDrawer.vue
+++ b/src/components/standalone/firewall/rules/CreateOrEditFirewallRuleDrawer.vue
@@ -720,7 +720,8 @@ async function saveRule() {
       return tag.id
     }),
     log: isLoggingEnabled.value,
-    system_rule: props.currentRule?.system_rule || false
+    system_rule: props.currentRule?.system_rule || false,
+    true_zone: props.currentRule?.true_zone || false
   }
 
   if (isEditingRule.value && props.currentRule) {

--- a/src/components/standalone/firewall/rules/CreateOrEditFirewallRuleDrawer.vue
+++ b/src/components/standalone/firewall/rules/CreateOrEditFirewallRuleDrawer.vue
@@ -721,7 +721,7 @@ async function saveRule() {
     }),
     log: isLoggingEnabled.value,
     system_rule: props.currentRule?.system_rule || false,
-    true_zone: props.currentRule?.true_zone || false
+    active_zone: props.currentRule?.active_zone || false
   }
 
   if (isEditingRule.value && props.currentRule) {

--- a/src/components/standalone/firewall/rules/FirewallRulesTable.vue
+++ b/src/components/standalone/firewall/rules/FirewallRulesTable.vue
@@ -99,7 +99,7 @@ const filteredRules = computed(() => {
 
 // isEnable follows rule.enabled and rule.active_zone
 function isEnabled(rule: FirewallRule): boolean {
-  return rule.enabled && rule.active_zone
+  return !!rule.enabled && !!rule.active_zone
 }
 
 watch(

--- a/src/components/standalone/firewall/rules/FirewallRulesTable.vue
+++ b/src/components/standalone/firewall/rules/FirewallRulesTable.vue
@@ -97,6 +97,11 @@ const filteredRules = computed(() => {
   }
 })
 
+// enable follows rule.enabled and rule.active_zone
+const enabled = computed(() => {
+  return (rule: FirewallRule) => rule.enabled && rule.active_zone
+})
+
 watch(
   () => props.rules,
   () => {
@@ -179,7 +184,7 @@ function getRuleActionIcon(ruleTarget: string) {
 }
 
 function getRuleActionColor(rule: FirewallRule) {
-  if (!rule.enabled || !rule.active_zone) {
+  if (!enabled.value) {
     return 'text-gray-500 dark:text-gray-400'
   }
 
@@ -323,13 +328,13 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                   v-if="!textFilter"
                   :class="[
                     'cursor-move text-center hover:bg-opacity-50 hover:dark:bg-opacity-70',
-                    !rule.enabled || !rule.active_zone ? disabledRuleClasses : ''
+                    !enabled(rule) ? disabledRuleClasses : ''
                   ]"
                 >
                   <FontAwesomeIcon :icon="faGripVertical" />
                 </td>
                 <!-- cannot drag & drop rules with active text filter -->
-                <td v-else :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
+                <td v-else :class="!enabled(rule) ? disabledRuleClasses : ''">
                   <NeTooltip triggerEvent="mouseenter focus" placement="top-start">
                     <template #trigger>
                       <FontAwesomeIcon
@@ -343,12 +348,12 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                   </NeTooltip>
                 </td>
                 <!-- name -->
-                <td :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
+                <td :class="!enabled(rule) ? disabledRuleClasses : ''">
                   <div
                     class="flex items-center justify-between gap-2 border-r border-gray-200 pr-4 dark:border-gray-600"
                   >
                     <div>
-                      <div :class="{ 'opacity-50': !rule.enabled || !rule.active_zone }">
+                      <div :class="{ 'opacity-50': !enabled(rule) }">
                         {{ rule.name }}
                       </div>
                       <div v-if="!rule.active_zone" class="mt-4">
@@ -403,43 +408,38 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                   </div>
                 </td>
                 <!-- source -->
-                <td :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
+                <td :class="!enabled(rule) ? disabledRuleClasses : ''">
                   <SourceOrDestinationRuleColumn
                     :rule="rule"
                     columnType="source"
                     :rulesType="rulesType"
-                    :enabled="rule.enabled && rule.active_zone"
+                    :enabled="enabled(rule)"
                     :hostSets="hostSets"
                     :domainSets="domainSets"
                     :loadingObjects="loadingListHostSets || loadingListDomainSets"
                   />
                 </td>
                 <!-- destination -->
-                <td :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
+                <td :class="!enabled(rule) ? disabledRuleClasses : ''">
                   <SourceOrDestinationRuleColumn
                     :rule="rule"
                     columnType="destination"
                     :rulesType="rulesType"
-                    :enabled="rule.enabled && rule.active_zone"
+                    :enabled="enabled(rule)"
                     :hostSets="hostSets"
                     :domainSets="domainSets"
                     :loadingObjects="loadingListHostSets || loadingListDomainSets"
                   />
                 </td>
                 <!-- service -->
-                <td :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
-                  <span :class="{ 'opacity-50': !rule.enabled || !rule.active_zone }">
+                <td :class="!enabled(rule) ? disabledRuleClasses : ''">
+                  <span :class="{ 'opacity-50': !enabled(rule) }">
                     {{ getServiceText(rule) }}
                   </span>
                 </td>
                 <!-- action -->
-                <td :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
-                  <span
-                    :class="[
-                      'flex items-center gap-x-2',
-                      { 'opacity-50': !rule.enabled || !rule.active_zone }
-                    ]"
-                  >
+                <td :class="!enabled(rule) ? disabledRuleClasses : ''">
+                  <span :class="['flex items-center gap-x-2', { 'opacity-50': !enabled(rule) }]">
                     <font-awesome-icon
                       :icon="['fas', getRuleActionIcon(rule.target)]"
                       :class="getRuleActionColor(rule)"
@@ -447,7 +447,7 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                     {{ rule.target }}
                   </span>
                 </td>
-                <td :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
+                <td :class="!enabled(rule) ? disabledRuleClasses : ''">
                   <!-- edit and kebab menu -->
                   <div class="flex justify-end gap-2">
                     <NeButton kind="tertiary" @click="emit('editRule', rule)">

--- a/src/components/standalone/firewall/rules/FirewallRulesTable.vue
+++ b/src/components/standalone/firewall/rules/FirewallRulesTable.vue
@@ -179,7 +179,7 @@ function getRuleActionIcon(ruleTarget: string) {
 }
 
 function getRuleActionColor(rule: FirewallRule) {
-  if (!rule.enabled || !rule.true_zone) {
+  if (!rule.enabled || !rule.active_zone) {
     return 'text-gray-500 dark:text-gray-400'
   }
 
@@ -323,13 +323,13 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                   v-if="!textFilter"
                   :class="[
                     'cursor-move text-center hover:bg-opacity-50 hover:dark:bg-opacity-70',
-                    !rule.enabled || !rule.true_zone ? disabledRuleClasses : ''
+                    !rule.enabled || !rule.active_zone ? disabledRuleClasses : ''
                   ]"
                 >
                   <FontAwesomeIcon :icon="faGripVertical" />
                 </td>
                 <!-- cannot drag & drop rules with active text filter -->
-                <td v-else :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
+                <td v-else :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
                   <NeTooltip triggerEvent="mouseenter focus" placement="top-start">
                     <template #trigger>
                       <FontAwesomeIcon
@@ -343,15 +343,15 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                   </NeTooltip>
                 </td>
                 <!-- name -->
-                <td :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
+                <td :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
                   <div
                     class="flex items-center justify-between gap-2 border-r border-gray-200 pr-4 dark:border-gray-600"
                   >
                     <div>
-                      <div :class="{ 'opacity-50': !rule.enabled || !rule.true_zone }">
+                      <div :class="{ 'opacity-50': !rule.enabled || !rule.active_zone }">
                         {{ rule.name }}
                       </div>
-                      <div v-if="!rule.true_zone" class="mt-4">
+                      <div v-if="!rule.active_zone" class="mt-4">
                         <NeTooltip triggerEvent="mouseenter focus" placement="top-start">
                           <template #trigger>
                             <NeBadge
@@ -403,41 +403,41 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                   </div>
                 </td>
                 <!-- source -->
-                <td :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
+                <td :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
                   <SourceOrDestinationRuleColumn
                     :rule="rule"
                     columnType="source"
                     :rulesType="rulesType"
-                    :enabled="rule.enabled && rule.true_zone"
+                    :enabled="rule.enabled && rule.active_zone"
                     :hostSets="hostSets"
                     :domainSets="domainSets"
                     :loadingObjects="loadingListHostSets || loadingListDomainSets"
                   />
                 </td>
                 <!-- destination -->
-                <td :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
+                <td :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
                   <SourceOrDestinationRuleColumn
                     :rule="rule"
                     columnType="destination"
                     :rulesType="rulesType"
-                    :enabled="rule.enabled && rule.true_zone"
+                    :enabled="rule.enabled && rule.active_zone"
                     :hostSets="hostSets"
                     :domainSets="domainSets"
                     :loadingObjects="loadingListHostSets || loadingListDomainSets"
                   />
                 </td>
                 <!-- service -->
-                <td :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
-                  <span :class="{ 'opacity-50': !rule.enabled || !rule.true_zone }">
+                <td :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
+                  <span :class="{ 'opacity-50': !rule.enabled || !rule.active_zone }">
                     {{ getServiceText(rule) }}
                   </span>
                 </td>
                 <!-- action -->
-                <td :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
+                <td :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
                   <span
                     :class="[
                       'flex items-center gap-x-2',
-                      { 'opacity-50': !rule.enabled || !rule.true_zone }
+                      { 'opacity-50': !rule.enabled || !rule.active_zone }
                     ]"
                   >
                     <font-awesome-icon
@@ -447,7 +447,7 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                     {{ rule.target }}
                   </span>
                 </td>
-                <td :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
+                <td :class="!rule.enabled || !rule.active_zone ? disabledRuleClasses : ''">
                   <!-- edit and kebab menu -->
                   <div class="flex justify-end gap-2">
                     <NeButton kind="tertiary" @click="emit('editRule', rule)">

--- a/src/components/standalone/firewall/rules/FirewallRulesTable.vue
+++ b/src/components/standalone/firewall/rules/FirewallRulesTable.vue
@@ -6,7 +6,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { NeButton, NeInlineNotification, NeLink } from '@nethesis/vue-components'
-import { NeSkeleton, NeTooltip, NeDropdown } from '@nethesis/vue-components'
+import { NeSkeleton, NeTooltip, NeDropdown, NeBadge } from '@nethesis/vue-components'
 import { ref, type PropType, watch, computed, onMounted } from 'vue'
 import NeTable from '@/components/standalone/NeTable.vue'
 import { isEmpty } from 'lodash-es'
@@ -179,7 +179,7 @@ function getRuleActionIcon(ruleTarget: string) {
 }
 
 function getRuleActionColor(rule: FirewallRule) {
-  if (!rule.enabled) {
+  if (!rule.enabled || !rule.true_zone) {
     return 'text-gray-500 dark:text-gray-400'
   }
 
@@ -323,13 +323,13 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                   v-if="!textFilter"
                   :class="[
                     'cursor-move text-center hover:bg-opacity-50 hover:dark:bg-opacity-70',
-                    !rule.enabled ? disabledRuleClasses : ''
+                    !rule.enabled || !rule.true_zone ? disabledRuleClasses : ''
                   ]"
                 >
                   <FontAwesomeIcon :icon="faGripVertical" />
                 </td>
                 <!-- cannot drag & drop rules with active text filter -->
-                <td v-else :class="!rule.enabled ? disabledRuleClasses : ''">
+                <td v-else :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
                   <NeTooltip triggerEvent="mouseenter focus" placement="top-start">
                     <template #trigger>
                       <FontAwesomeIcon
@@ -343,21 +343,43 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                   </NeTooltip>
                 </td>
                 <!-- name -->
-                <td :class="!rule.enabled ? disabledRuleClasses : ''">
+                <td :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
                   <div
                     class="flex items-center justify-between gap-2 border-r border-gray-200 pr-4 dark:border-gray-600"
                   >
                     <div>
-                      <div :class="{ 'opacity-50': !rule.enabled }">
+                      <div :class="{ 'opacity-50': !rule.enabled || !rule.true_zone }">
                         {{ rule.name }}
                       </div>
-                      <div v-if="!rule.enabled" class="mt-2 opacity-50">
-                        <font-awesome-icon
-                          :icon="['fas', 'circle-xmark']"
-                          class="mr-2 h-4 w-4"
-                          aria-hidden="true"
-                        />
-                        <span>{{ t('common.disabled') }}</span>
+                      <div v-if="!rule.true_zone" class="mt-4">
+                        <NeTooltip triggerEvent="mouseenter focus" placement="top-start">
+                          <template #trigger>
+                            <NeBadge
+                              kind="warning"
+                              class="-mt-2"
+                              :icon="['fas', 'triangle-exclamation']"
+                              :text="t('standalone.firewall_rules.inactive')"
+                            />
+                          </template>
+                          <template #content>
+                            {{ t('standalone.firewall_rules.zone_no_longer_exists') }}
+                          </template>
+                        </NeTooltip>
+                      </div>
+                      <div v-else-if="!rule.enabled" class="mt-4">
+                        <NeTooltip triggerEvent="mouseenter focus" placement="top-start">
+                          <template #trigger>
+                            <NeBadge
+                              kind="secondary"
+                              class="-mt-2"
+                              :icon="['fas', 'circle-xmark']"
+                              :text="t('common.disabled')"
+                            />
+                          </template>
+                          <template #content>
+                            {{ t('standalone.firewall_rules.disabled_rule') }}
+                          </template>
+                        </NeTooltip>
                       </div>
                     </div>
                     <!-- show details icon -->
@@ -381,38 +403,43 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                   </div>
                 </td>
                 <!-- source -->
-                <td :class="!rule.enabled ? disabledRuleClasses : ''">
+                <td :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
                   <SourceOrDestinationRuleColumn
                     :rule="rule"
                     columnType="source"
                     :rulesType="rulesType"
-                    :enabled="rule.enabled"
+                    :enabled="rule.enabled && rule.true_zone"
                     :hostSets="hostSets"
                     :domainSets="domainSets"
                     :loadingObjects="loadingListHostSets || loadingListDomainSets"
                   />
                 </td>
                 <!-- destination -->
-                <td :class="!rule.enabled ? disabledRuleClasses : ''">
+                <td :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
                   <SourceOrDestinationRuleColumn
                     :rule="rule"
                     columnType="destination"
                     :rulesType="rulesType"
-                    :enabled="rule.enabled"
+                    :enabled="rule.enabled && rule.true_zone"
                     :hostSets="hostSets"
                     :domainSets="domainSets"
                     :loadingObjects="loadingListHostSets || loadingListDomainSets"
                   />
                 </td>
                 <!-- service -->
-                <td :class="!rule.enabled ? disabledRuleClasses : ''">
-                  <span :class="{ 'opacity-50': !rule.enabled }">
+                <td :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
+                  <span :class="{ 'opacity-50': !rule.enabled || !rule.true_zone }">
                     {{ getServiceText(rule) }}
                   </span>
                 </td>
                 <!-- action -->
-                <td :class="!rule.enabled ? disabledRuleClasses : ''">
-                  <span :class="['flex items-center gap-x-2', { 'opacity-50': !rule.enabled }]">
+                <td :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
+                  <span
+                    :class="[
+                      'flex items-center gap-x-2',
+                      { 'opacity-50': !rule.enabled || !rule.true_zone }
+                    ]"
+                  >
                     <font-awesome-icon
                       :icon="['fas', getRuleActionIcon(rule.target)]"
                       :class="getRuleActionColor(rule)"
@@ -420,7 +447,7 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                     {{ rule.target }}
                   </span>
                 </td>
-                <td :class="!rule.enabled ? disabledRuleClasses : ''">
+                <td :class="!rule.enabled || !rule.true_zone ? disabledRuleClasses : ''">
                   <!-- edit and kebab menu -->
                   <div class="flex justify-end gap-2">
                     <NeButton kind="tertiary" @click="emit('editRule', rule)">

--- a/src/components/standalone/firewall/rules/FirewallRulesTable.vue
+++ b/src/components/standalone/firewall/rules/FirewallRulesTable.vue
@@ -97,10 +97,10 @@ const filteredRules = computed(() => {
   }
 })
 
-// enable follows rule.enabled and rule.active_zone
-const enabled = computed(() => {
-  return (rule: FirewallRule) => rule.enabled && rule.active_zone
-})
+// isEnable follows rule.enabled and rule.active_zone
+function isEnabled(rule: FirewallRule): boolean {
+  return rule.enabled && rule.active_zone
+}
 
 watch(
   () => props.rules,
@@ -184,7 +184,7 @@ function getRuleActionIcon(ruleTarget: string) {
 }
 
 function getRuleActionColor(rule: FirewallRule) {
-  if (!enabled.value) {
+  if (isEnabled(rule)) {
     return 'text-gray-500 dark:text-gray-400'
   }
 
@@ -328,13 +328,13 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                   v-if="!textFilter"
                   :class="[
                     'cursor-move text-center hover:bg-opacity-50 hover:dark:bg-opacity-70',
-                    !enabled(rule) ? disabledRuleClasses : ''
+                    !isEnabled(rule) ? disabledRuleClasses : ''
                   ]"
                 >
                   <FontAwesomeIcon :icon="faGripVertical" />
                 </td>
                 <!-- cannot drag & drop rules with active text filter -->
-                <td v-else :class="!enabled(rule) ? disabledRuleClasses : ''">
+                <td v-else :class="!isEnabled(rule) ? disabledRuleClasses : ''">
                   <NeTooltip triggerEvent="mouseenter focus" placement="top-start">
                     <template #trigger>
                       <FontAwesomeIcon
@@ -348,12 +348,12 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                   </NeTooltip>
                 </td>
                 <!-- name -->
-                <td :class="!enabled(rule) ? disabledRuleClasses : ''">
+                <td :class="!isEnabled(rule) ? disabledRuleClasses : ''">
                   <div
                     class="flex items-center justify-between gap-2 border-r border-gray-200 pr-4 dark:border-gray-600"
                   >
                     <div>
-                      <div :class="{ 'opacity-50': !enabled(rule) }">
+                      <div :class="{ 'opacity-50': !isEnabled(rule) }">
                         {{ rule.name }}
                       </div>
                       <div v-if="!rule.active_zone" class="mt-4">
@@ -408,38 +408,38 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                   </div>
                 </td>
                 <!-- source -->
-                <td :class="!enabled(rule) ? disabledRuleClasses : ''">
+                <td :class="!isEnabled(rule) ? disabledRuleClasses : ''">
                   <SourceOrDestinationRuleColumn
                     :rule="rule"
                     columnType="source"
                     :rulesType="rulesType"
-                    :enabled="enabled(rule)"
+                    :enabled="isEnabled(rule)"
                     :hostSets="hostSets"
                     :domainSets="domainSets"
                     :loadingObjects="loadingListHostSets || loadingListDomainSets"
                   />
                 </td>
                 <!-- destination -->
-                <td :class="!enabled(rule) ? disabledRuleClasses : ''">
+                <td :class="!isEnabled(rule) ? disabledRuleClasses : ''">
                   <SourceOrDestinationRuleColumn
                     :rule="rule"
                     columnType="destination"
                     :rulesType="rulesType"
-                    :enabled="enabled(rule)"
+                    :enabled="isEnabled(rule)"
                     :hostSets="hostSets"
                     :domainSets="domainSets"
                     :loadingObjects="loadingListHostSets || loadingListDomainSets"
                   />
                 </td>
                 <!-- service -->
-                <td :class="!enabled(rule) ? disabledRuleClasses : ''">
-                  <span :class="{ 'opacity-50': !enabled(rule) }">
+                <td :class="!isEnabled(rule) ? disabledRuleClasses : ''">
+                  <span :class="{ 'opacity-50': !isEnabled(rule) }">
                     {{ getServiceText(rule) }}
                   </span>
                 </td>
                 <!-- action -->
-                <td :class="!enabled(rule) ? disabledRuleClasses : ''">
-                  <span :class="['flex items-center gap-x-2', { 'opacity-50': !enabled(rule) }]">
+                <td :class="!isEnabled(rule) ? disabledRuleClasses : ''">
+                  <span :class="['flex items-center gap-x-2', { 'opacity-50': !isEnabled(rule) }]">
                     <font-awesome-icon
                       :icon="['fas', getRuleActionIcon(rule.target)]"
                       :class="getRuleActionColor(rule)"
@@ -447,7 +447,7 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                     {{ rule.target }}
                   </span>
                 </td>
-                <td :class="!enabled(rule) ? disabledRuleClasses : ''">
+                <td :class="!isEnabled(rule) ? disabledRuleClasses : ''">
                   <!-- edit and kebab menu -->
                   <div class="flex justify-end gap-2">
                     <NeButton kind="tertiary" @click="emit('editRule', rule)">

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -1401,7 +1401,10 @@
       "any_source_address": "Any source address",
       "any_destination_address": "Any destination address",
       "source_object": "Source object",
-      "destination_object": "Destination object"
+      "destination_object": "Destination object",
+      "inactive": "Inactive",
+      "zone_no_longer_exists": "This rule is not active because it uses a zone that no longer exists",
+      "disabled_rule": "This rule is disabled by its configuration, you can enable it again"
     },
     "firewall": {
       "title": "Firewall"

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -1403,8 +1403,8 @@
       "source_object": "Source object",
       "destination_object": "Destination object",
       "inactive": "Inactive",
-      "zone_no_longer_exists": "This rule is not active because it uses a zone that no longer exists",
-      "disabled_rule": "This rule is disabled by its configuration, you can enable it again"
+      "zone_no_longer_exists": "This rule is inactive because it uses a zone that no longer exists",
+      "disabled_rule": "This rule has been manually disabled, but can be re-enabled"
     },
     "firewall": {
       "title": "Firewall"

--- a/src/stores/standalone/firewall.ts
+++ b/src/stores/standalone/firewall.ts
@@ -70,6 +70,7 @@ export interface FirewallRule {
   ns_tag: string[] // tags
   add_to_top: boolean // add rule to top?
   system_rule: boolean // system rule?
+  true_zone: boolean // zone exist?
 }
 
 export interface NatRule {

--- a/src/stores/standalone/firewall.ts
+++ b/src/stores/standalone/firewall.ts
@@ -70,7 +70,7 @@ export interface FirewallRule {
   ns_tag: string[] // tags
   add_to_top: boolean // add rule to top?
   system_rule: boolean // system rule?
-  active_zone: boolean // zone exists?
+  active_zone?: boolean // zone exists?
 }
 
 export interface NatRule {

--- a/src/stores/standalone/firewall.ts
+++ b/src/stores/standalone/firewall.ts
@@ -70,7 +70,7 @@ export interface FirewallRule {
   ns_tag: string[] // tags
   add_to_top: boolean // add rule to top?
   system_rule: boolean // system rule?
-  true_zone: boolean // zone exist?
+  active_zone: boolean // zone exist?
 }
 
 export interface NatRule {

--- a/src/stores/standalone/firewall.ts
+++ b/src/stores/standalone/firewall.ts
@@ -70,7 +70,7 @@ export interface FirewallRule {
   ns_tag: string[] // tags
   add_to_top: boolean // add rule to top?
   system_rule: boolean // system rule?
-  active_zone: boolean // zone exist?
+  active_zone: boolean // zone exists?
 }
 
 export interface NatRule {


### PR DESCRIPTION
Introduce a true_zone property to the FirewallRule interface, improve display logic to account for zone existence, and add new translations for inactive and disabled firewall rules.

https://github.com/NethServer/nethsecurity/issues/899

https://github.com/user-attachments/assets/463d96b5-78b1-4184-bf6c-61302b7d64f9



https://github.com/user-attachments/assets/f6fd4ac7-e271-4161-a8af-ab6d86b16945


