### PR TITLE
fix(port forward): adding tooltip for disabled port forwards

### DIFF
--- a/src/components/standalone/firewall/PortForwardTable.vue
+++ b/src/components/standalone/firewall/PortForwardTable.vue
@@ -6,7 +6,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import type { PortForward } from '@/views/standalone/firewall/PortForward.vue'
-import { toRefs } from 'vue'
+import { toRefs, computed } from 'vue'
 import {
   NeDropdown,
   NeTable,
@@ -15,8 +15,11 @@ import {
   NeTableBody,
   NeTableRow,
   NeTableCell,
-  NeButton
+  NeButton,
+  NeTooltip,
+  NeBadge
 } from '@nethesis/vue-components'
+import { useObjectStore } from '@/stores/standalone/objects'
 import ObjectTooltip from '@/components/standalone/users_objects/ObjectTooltip.vue'
 
 const { t } = useI18n()
@@ -27,6 +30,13 @@ const props = defineProps<{
 }>()
 
 const { portForwards, header } = toRefs(props)
+
+const objects = useObjectStore()
+
+// Computed property to check if the header contains a hyphen
+const hasHyphen = computed(() => {
+  return header.value.includes('-')
+})
 
 const emit = defineEmits([
   'port-forward-duplicate',
@@ -117,6 +127,26 @@ function getCellClasses(item: PortForward) {
         <NeTableRow v-for="item in portForwards" :key="item.id">
           <NeTableCell :data-label="t('standalone.port_forward.name')">
             <p :class="[...getCellClasses(item)]">{{ item.name }}</p>
+            <div v-if="hasHyphen">
+              <NeTooltip triggerEvent="mouseenter focus" placement="top-start">
+                <template #trigger>
+                  <NeBadge
+                    kind="warning"
+                    size="xs"
+                    class="mt-2"
+                    :icon="['fas', 'triangle-exclamation']"
+                    :text="t('standalone.port_forward.inactive')"
+                  />
+                </template>
+                <template #content>
+                  {{
+                    t('standalone.port_forward.range_object_not_compatible', {
+                      name: objects.getRecord(item.ns_dst ?? '')?.name || '-'
+                    })
+                  }}
+                </template>
+              </NeTooltip>
+            </div>
           </NeTableCell>
           <NeTableCell :data-label="t('standalone.port_forward.source_port')">
             <p :class="[...getCellClasses(item)]">

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -1357,7 +1357,7 @@
       "no_object": "No object",
       "port_forwards_for_destination_name": "Port forwards for destination '{name}'",
       "inactive": "Inactive",
-      "range_object_not_compatible": "This port forward is inactive because host set [{name}] include an ip range"
+      "range_object_not_compatible": "This port forward is inactive because host set '{name}' includes an ip range"
     },
     "firewall_rules": {
       "title": "Firewall rules",

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -1357,7 +1357,7 @@
       "no_object": "No object",
       "port_forwards_for_destination_name": "Port forwards for destination '{name}'",
       "inactive": "Inactive",
-      "range_object_not_compatible": "This port forward is inactive because host set '{name}' includes an ip range"
+      "range_object_not_compatible": "This port forward is inactive because host set '{name}' includes an IP range"
     },
     "firewall_rules": {
       "title": "Firewall rules",

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -1355,7 +1355,9 @@
       "restricted_object": "Restricted object",
       "restricted_object_tooltip": "All objects supported, except host sets with IP ranges",
       "no_object": "No object",
-      "port_forwards_for_destination_name": "Port forwards for destination '{name}'"
+      "port_forwards_for_destination_name": "Port forwards for destination '{name}'",
+      "inactive": "Inactive",
+      "range_object_not_compatible": "This port forward is inactive because host set [{name}] include an ip range"
     },
     "firewall_rules": {
       "title": "Firewall rules",


### PR DESCRIPTION
Introduce a tooltip for inactive port forwards when the header contains a hyphen and add translations for the inactive status and range object compatibility.

https://github.com/NethServer/nethsecurity/issues/898

![image](https://github.com/user-attachments/assets/4a654e3c-382f-4a3a-8172-18f07fca5dbe)

![image](https://github.com/user-attachments/assets/58a9d617-9044-4c11-9b57-091946ebd413)


![image](https://github.com/user-attachments/assets/738cd35d-7968-4d82-994a-3160ea644706)

if I revert the host range

![image](https://github.com/user-attachments/assets/0e40fc03-586b-47a2-b901-ad9ddf59059a)
![image](https://github.com/user-attachments/assets/2bebf1e8-5b6b-4916-b23c-13010d05755d)

Note:
it seems we need to save the upper unsaved change button if we want the change is effective