### PR TITLE
fix(port forward): removing tooltip for disabled port forwards

### DIFF
--- a/src/components/standalone/firewall/PortForwardTable.vue
+++ b/src/components/standalone/firewall/PortForwardTable.vue
@@ -6,7 +6,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import type { PortForward } from '@/views/standalone/firewall/PortForward.vue'
-import { toRefs, computed } from 'vue'
+import { toRefs } from 'vue'
 import {
   NeDropdown,
   NeTable,
@@ -15,11 +15,8 @@ import {
   NeTableBody,
   NeTableRow,
   NeTableCell,
-  NeButton,
-  NeTooltip,
-  NeBadge
+  NeButton
 } from '@nethesis/vue-components'
-import { useObjectStore } from '@/stores/standalone/objects'
 import ObjectTooltip from '@/components/standalone/users_objects/ObjectTooltip.vue'
 
 const { t } = useI18n()
@@ -30,13 +27,6 @@ const props = defineProps<{
 }>()
 
 const { portForwards, header } = toRefs(props)
-
-const objects = useObjectStore()
-
-// Computed property to check if the header contains a hyphen
-const hasHyphen = computed(() => {
-  return header.value.includes('-')
-})
 
 const emit = defineEmits([
   'port-forward-duplicate',
@@ -127,26 +117,6 @@ function getCellClasses(item: PortForward) {
         <NeTableRow v-for="item in portForwards" :key="item.id">
           <NeTableCell :data-label="t('standalone.port_forward.name')">
             <p :class="[...getCellClasses(item)]">{{ item.name }}</p>
-            <div v-if="hasHyphen">
-              <NeTooltip triggerEvent="mouseenter focus" placement="top-start">
-                <template #trigger>
-                  <NeBadge
-                    kind="warning"
-                    size="xs"
-                    class="mt-2"
-                    :icon="['fas', 'triangle-exclamation']"
-                    :text="t('standalone.port_forward.inactive')"
-                  />
-                </template>
-                <template #content>
-                  {{
-                    t('standalone.port_forward.range_object_not_compatible', {
-                      name: objects.getRecord(item.ns_dst ?? '')?.name || '-'
-                    })
-                  }}
-                </template>
-              </NeTooltip>
-            </div>
           </NeTableCell>
           <NeTableCell :data-label="t('standalone.port_forward.source_port')">
             <p :class="[...getCellClasses(item)]">

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -1355,9 +1355,7 @@
       "restricted_object": "Restricted object",
       "restricted_object_tooltip": "All objects supported, except host sets with IP ranges",
       "no_object": "No object",
-      "port_forwards_for_destination_name": "Port forwards for destination '{name}'",
-      "inactive": "Inactive",
-      "range_object_not_compatible": "This port forward is inactive because host set '{name}' includes an IP range"
+      "port_forwards_for_destination_name": "Port forwards for destination '{name}'"
     },
     "firewall_rules": {
       "title": "Firewall rules",


### PR DESCRIPTION
Reverts NethServer/nethsecurity-ui#482

To avoid such scenario, we need to improve the validation of objects.

See:

- https://github.com/NethServer/nethsecurity/issues/898
- https://github.com/NethServer/nethsecurity/issues/1032