### PR TITLE
fix(ts-dns): improve blocklist table output

### DIFF
--- a/src/components/standalone/security/threat_shield/BlocklistTable.vue
+++ b/src/components/standalone/security/threat_shield/BlocklistTable.vue
@@ -19,7 +19,7 @@ import {
   useItemPagination
 } from '@nethesis/vue-components'
 import { range } from 'lodash-es'
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 
 const props = defineProps<{
   blocklists: Blocklist[]
@@ -34,7 +34,16 @@ defineEmits<{
 
 const { t, te } = useI18n()
 const pageSize = ref(10)
-const { currentPage, paginatedItems } = useItemPagination(() => props.blocklists, {
+const sortedBlocklists = computed(() => {
+  return [...props.blocklists].sort((a, b) => {
+    if (a.type === b.type) {
+      return b.confidence - a.confidence
+    }
+    return a.type === 'enterprise' ? -1 : 1
+  })
+})
+
+const { currentPage, paginatedItems } = useItemPagination(() => sortedBlocklists.value, {
   itemsPerPage: pageSize
 })
 
@@ -100,7 +109,7 @@ function getBlocklistName(blocklist: Blocklist) {
           {{
             te(`standalone.threat_shield_dns.description_${item.name}`)
               ? t(`standalone.threat_shield_dns.description_${item.name}`)
-              : t('standalone.threat_shield.unknown')
+              : item.description
           }}
         </NeTableCell>
         <NeTableCell :data-label="t('standalone.threat_shield.confidence')">

--- a/src/components/standalone/security/threat_shield/BlocklistTable.vue
+++ b/src/components/standalone/security/threat_shield/BlocklistTable.vue
@@ -19,7 +19,7 @@ import {
   useItemPagination
 } from '@nethesis/vue-components'
 import { range } from 'lodash-es'
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 
 const props = defineProps<{
   blocklists: Blocklist[]
@@ -34,16 +34,7 @@ defineEmits<{
 
 const { t, te } = useI18n()
 const pageSize = ref(10)
-const sortedBlocklists = computed(() => {
-  return [...props.blocklists].sort((a, b) => {
-    if (a.type === b.type) {
-      return b.confidence - a.confidence
-    }
-    return a.type === 'enterprise' ? -1 : 1
-  })
-})
-
-const { currentPage, paginatedItems } = useItemPagination(() => sortedBlocklists.value, {
+const { currentPage, paginatedItems } = useItemPagination(() => props.blocklists, {
   itemsPerPage: pageSize
 })
 

--- a/src/stores/standalone/threatShield.ts
+++ b/src/stores/standalone/threatShield.ts
@@ -83,11 +83,11 @@ export const useThreatShieldStore = defineStore('threatShield', () => {
     try {
       const res = await ubusCall('ns.threatshield', 'dns-list-blocklist')
       const blocklists = res.data.data as Blocklist[]
-      // sort by confidence in descending order and then alphabetically
+      // show enterprise lists first, then sort alphabetically
       dnsBlocklists.value = blocklists
         .sort(sortByProperty('name'))
         .reverse()
-        .sort(sortByProperty('confidence'))
+        .sort(sortByProperty('type'))
         .reverse()
     } catch (err: any) {
       console.error(err)


### PR DESCRIPTION
Changes:
- enterprise blocklist are listed on top, other lists are sorted by confidence
- if the translation language is not set, make sure to display the original description from API

Output example:
![image](https://github.com/user-attachments/assets/ecb60781-0354-48ce-b66a-973972146998)


NethServer/nethsecurity#906