### PR TITLE
fix: adding error for DHCP overlap

### DIFF
--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -401,7 +401,8 @@
     "duplicate_suppression": "Suppression already exists",
     "invalid_old_password": "Old password is incorrect",
     "key_already_exists": "Key already exists",
-    "key_invalid_format": "Invalid key format"
+    "key_invalid_format": "Invalid key format",
+    "dhcp_range_cannot_contain_interface": "The firewall IP address must be outside the DHCP range."
   },
   "ne_text_input": {
     "show_password": "Show password",


### PR DESCRIPTION
Example screenshot:
![image](https://github.com/user-attachments/assets/5c3b507c-d31b-4f5f-837b-a07570e3e151)

Ref:
- https://github.com/NethServer/nethsecurity/issues/1089
