### PR TITLE
fix(monitoring): improve IP field retrieval

### DIFF
--- a/src/components/standalone/monitoring/ConnectivityMonitor.vue
+++ b/src/components/standalone/monitoring/ConnectivityMonitor.vue
@@ -102,7 +102,7 @@ watchEffect(async () => {
   for (const wan of wans.value) {
     let publicIpAddresses: string[] = []
     let status = getMwanStatus(wan.iface)
-    if (status == 'online') {
+    if (status == 'online' || status == '-') {
       publicIpAddresses = await retrievePublicIpAddresses(wan)
     }
     // remap disabled (cable detached) status to offline

--- a/src/components/standalone/monitoring/connectivity/WanConnectionsCard.vue
+++ b/src/components/standalone/monitoring/connectivity/WanConnectionsCard.vue
@@ -104,19 +104,30 @@ function getQosRule(item: Wan) {
           <NeTableCell :data-label="t('common.status')">
             <div class="flex items-center gap-2">
               <font-awesome-icon
-                :icon="['fas', item.status == 'online' ? 'circle-check' : 'circle-xmark']"
+                :icon="[
+                  'fas',
+                  item.status == 'online'
+                    ? 'circle-check'
+                    : item.status == 'offline'
+                      ? 'circle-xmark'
+                      : 'circle-question'
+                ]"
                 :class="[
                   'h-4 w-4',
                   item.status == 'online'
                     ? 'text-green-600 dark:text-green-400'
-                    : 'text-rose-600 dark:text-rose-400'
+                    : item.status == 'offline'
+                      ? 'text-rose-600 dark:text-rose-400'
+                      : 'text-gray-600 dark:text-gray-400'
                 ]"
                 aria-hidden="true"
               />
               {{
                 item.status == 'online'
                   ? t('standalone.real_time_monitor.online')
-                  : t('standalone.real_time_monitor.offline')
+                  : item.status == 'offline'
+                    ? t('standalone.real_time_monitor.offline')
+                    : t('standalone.real_time_monitor.unknown')
               }}
             </div>
           </NeTableCell>

--- a/src/components/standalone/monitoring/connectivity/WanConnectionsCard.vue
+++ b/src/components/standalone/monitoring/connectivity/WanConnectionsCard.vue
@@ -24,7 +24,7 @@ import type { Wan } from '../ConnectivityMonitor.vue'
 import type { QoSInterface } from '@/views/standalone/network/QoSView.vue'
 import { ubusCall } from '@/lib/standalone/ubus'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { faCircleCheck, faCircleQuestion, faCircleXmark } from '@fortawesome/free-solid-svg-icons'
+import { faCircleCheck, faCircleXmark } from '@fortawesome/free-solid-svg-icons'
 
 const props = defineProps<{
   wanConnections: Wan[]
@@ -117,21 +117,13 @@ function getQosRule(item: Wan) {
                 class="h-4 w-4 text-rose-600 dark:text-rose-400"
                 aria-hidden="true"
               />
-              <FontAwesomeIcon
-                v-else
-                :icon="faCircleQuestion"
-                class="h-4 w-4 text-gray-600 dark:text-gray-400"
-                aria-hidden="true"
-              />
               <template v-if="item.status == 'online'">
                 {{ t('standalone.real_time_monitor.online') }}
               </template>
               <template v-else-if="item.status == 'offline'">
                 {{ t('standalone.real_time_monitor.offline') }}
               </template>
-              <template v-else>
-                {{ t('standalone.real_time_monitor.unknown') }}
-              </template>
+              <template v-else> - </template>
             </div>
           </NeTableCell>
           <NeTableCell :data-label="t('standalone.real_time_monitor.public_ip_address')">

--- a/src/components/standalone/monitoring/connectivity/WanConnectionsCard.vue
+++ b/src/components/standalone/monitoring/connectivity/WanConnectionsCard.vue
@@ -5,24 +5,26 @@
 
 <script setup lang="ts">
 import {
+  getAxiosErrorMessage,
   NeCard,
+  NeInlineNotification,
+  NePaginator,
+  NeSkeleton,
   NeTable,
+  NeTableBody,
+  NeTableCell,
   NeTableHead,
   NeTableHeadCell,
-  NeTableBody,
   NeTableRow,
-  NeTableCell,
-  NePaginator,
-  useItemPagination,
-  getAxiosErrorMessage,
-  NeInlineNotification,
-  NeSkeleton
+  useItemPagination
 } from '@nethesis/vue-components'
 import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { Wan } from '../ConnectivityMonitor.vue'
 import type { QoSInterface } from '@/views/standalone/network/QoSView.vue'
 import { ubusCall } from '@/lib/standalone/ubus'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { faCircleCheck, faCircleQuestion, faCircleXmark } from '@fortawesome/free-solid-svg-icons'
 
 const props = defineProps<{
   wanConnections: Wan[]
@@ -103,32 +105,33 @@ function getQosRule(item: Wan) {
           </NeTableCell>
           <NeTableCell :data-label="t('common.status')">
             <div class="flex items-center gap-2">
-              <font-awesome-icon
-                :icon="[
-                  'fas',
-                  item.status == 'online'
-                    ? 'circle-check'
-                    : item.status == 'offline'
-                      ? 'circle-xmark'
-                      : 'circle-question'
-                ]"
-                :class="[
-                  'h-4 w-4',
-                  item.status == 'online'
-                    ? 'text-green-600 dark:text-green-400'
-                    : item.status == 'offline'
-                      ? 'text-rose-600 dark:text-rose-400'
-                      : 'text-gray-600 dark:text-gray-400'
-                ]"
+              <FontAwesomeIcon
+                v-if="item.status == 'online'"
+                :icon="faCircleCheck"
+                class="h-4 w-4 text-green-600 dark:text-green-400"
                 aria-hidden="true"
               />
-              {{
-                item.status == 'online'
-                  ? t('standalone.real_time_monitor.online')
-                  : item.status == 'offline'
-                    ? t('standalone.real_time_monitor.offline')
-                    : t('standalone.real_time_monitor.unknown')
-              }}
+              <FontAwesomeIcon
+                v-else-if="item.status == 'offline'"
+                :icon="faCircleXmark"
+                class="h-4 w-4 text-rose-600 dark:text-rose-400"
+                aria-hidden="true"
+              />
+              <FontAwesomeIcon
+                v-else
+                :icon="faCircleQuestion"
+                class="h-4 w-4 text-gray-600 dark:text-gray-400"
+                aria-hidden="true"
+              />
+              <template v-if="item.status == 'online'">
+                {{ t('standalone.real_time_monitor.online') }}
+              </template>
+              <template v-else-if="item.status == 'offline'">
+                {{ t('standalone.real_time_monitor.offline') }}
+              </template>
+              <template v-else>
+                {{ t('standalone.real_time_monitor.unknown') }}
+              </template>
             </div>
           </NeTableCell>
           <NeTableCell :data-label="t('standalone.real_time_monitor.public_ip_address')">

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -2107,7 +2107,8 @@
       "public_ip_address": "Public IP address",
       "error_fetching_data": "Error fetching data",
       "remote_hosts": "Remote hosts",
-      "no_data_available": "No data available"
+      "no_data_available": "No data available",
+      "unknown": "Unknown"
     },
     "ping_latency_monitor": {
       "title": "Ping latency monitor",

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -2107,8 +2107,7 @@
       "public_ip_address": "Public IP address",
       "error_fetching_data": "Error fetching data",
       "remote_hosts": "Remote hosts",
-      "no_data_available": "No data available",
-      "unknown": "Unknown"
+      "no_data_available": "No data available"
     },
     "ping_latency_monitor": {
       "title": "Ping latency monitor",


### PR DESCRIPTION
Changes:
- always display all WANs
- retrieve the status from mwan: an installation with multiple WANs but without mwan configured is not good

mwan not configured:
![Screenshot From 2025-04-02 17-05-16](https://github.com/user-attachments/assets/19a031f4-a99a-4f22-80bc-63c2be5e93ae)
mwan configured: second wan is in disabled state but remapped to "offline"
![Screenshot From 2025-04-02 17-04-14](https://github.com/user-attachments/assets/acc5017d-8114-422a-92cb-86898bf0e7bf)


NethServer/nethsecurity#1148