### PR TITLE
fix(ssh): configure only main dropbear server

### DIFF
--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -598,7 +598,8 @@
         "allow_remote_host_connection": "Allow remote hosts to connect to local SSH forwarded ports",
         "tcp_port_too_low": "TCP port must be greater than 1",
         "tcp_port_too_high": "TCP port must be less than 65535",
-        "tcp_port_invalid": "TCP port is invalid"
+        "tcp_port_invalid": "TCP port is invalid",
+        "ssh_access.main_config_not_found": "Default SSH configuration not found"
       },
       "ssh_keys": {
         "description": "Public keys allow for passwordless SSH logins with a higher security compared to the use of plain passwords",


### PR DESCRIPTION
Make sure to configure the SSH server named main.
Otherwise when the HA is configured, the UI will show and configure dropbear instance dedicated to the HA.

Split from #533 

Companion PR: https://github.com/NethServer/nethsecurity/pull/871

Main issue: NethServer/nethsecurity#920