### PR TITLE
fix(dhcp): correct reservation name sorting

### DIFF
--- a/src/components/standalone/dns_dhcp/LeasesTable.vue
+++ b/src/components/standalone/dns_dhcp/LeasesTable.vue
@@ -98,7 +98,7 @@ const onSort = (payload: any) => {
     :label="t('sort.sort')"
     :options="[
       { id: 'hostname', label: t('standalone.dns_dhcp.hostname') },
-      { id: 'reservation', label: t('standalone.dns_dhcp.reservation_name') },
+      { id: 'description', label: t('standalone.dns_dhcp.reservation_name') },
       { id: 'interface', label: t('standalone.dns_dhcp.interface') },
       { id: 'expiration', label: t('standalone.dns_dhcp.lease_expiration') },
       { id: 'address', label: t('standalone.dns_dhcp.ip_address') }
@@ -130,7 +130,7 @@ const onSort = (payload: any) => {
       <NeTableHeadCell v-if="showDynamicLeases" column-key="expiration" sortable @sort="onSort">
         {{ t('standalone.dns_dhcp.lease_expiration') }}
       </NeTableHeadCell>
-      <NeTableHeadCell v-if="!showDynamicLeases" column-key="reservation" sortable @sort="onSort">
+      <NeTableHeadCell v-if="!showDynamicLeases" column-key="description" sortable @sort="onSort">
         {{ t('standalone.dns_dhcp.reservation_name') }}
       </NeTableHeadCell>
       <NeTableHeadCell>


### PR DESCRIPTION
The reservation_name was using the wrong key for sorting.

NethServer/nethsecurity#1087
