### PR TITLE
fix: replace string icons with IconDefinition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@nethesis/nethesis-brands-svg-icons": "github:nethesis/Font-Awesome#ns-brands",
         "@nethesis/nethesis-light-svg-icons": "github:nethesis/Font-Awesome#ns-light",
         "@nethesis/nethesis-solid-svg-icons": "github:nethesis/Font-Awesome#ns-solid",
-        "@nethesis/vue-components": "^1.7.0",
+        "@nethesis/vue-components": "^2.0.0",
         "@types/lodash-es": "^4.17.12",
         "@types/semver": "^7.5.8",
         "@vuepic/vue-datepicker": "^7.2.2",
@@ -1888,9 +1888,9 @@
       }
     },
     "node_modules/@nethesis/vue-components": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@nethesis/vue-components/-/vue-components-1.7.0.tgz",
-      "integrity": "sha512-ItT9FxllNyWdDucBDuECHqOd+Z+cw1KvsJgl66TKZHU9ydx4JHUvJzOZHdOfrsorBuRAqSo+dGYBVm2e3/1cWA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nethesis/vue-components/-/vue-components-2.0.0.tgz",
+      "integrity": "sha512-V/BsKfoiVHNQdcreFHyeC4hCp5dLx6FW0Ct0t35MwBU+qjdguJ/J94PE1Ko5LWZH99m3jBPueW6K6U9NJ+KtAA==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
         "@fortawesome/free-solid-svg-icons": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@nethesis/nethesis-brands-svg-icons": "github:nethesis/Font-Awesome#ns-brands",
     "@nethesis/nethesis-light-svg-icons": "github:nethesis/Font-Awesome#ns-light",
     "@nethesis/nethesis-solid-svg-icons": "github:nethesis/Font-Awesome#ns-solid",
-    "@nethesis/vue-components": "^1.7.0",
+    "@nethesis/vue-components": "^2.0.0",
     "@types/lodash-es": "^4.17.12",
     "@types/semver": "^7.5.8",
     "@vuepic/vue-datepicker": "^7.2.2",

--- a/src/components/controller/ControllerTopBar.vue
+++ b/src/components/controller/ControllerTopBar.vue
@@ -12,6 +12,7 @@ import { ref, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useThemeStore } from '@/stores/theme'
 import { useLoginStore } from '@/stores/controller/controllerLogin'
+import { faCircleUser, faMoon, faRightFromBracket, faSun } from '@fortawesome/free-solid-svg-icons'
 
 const emit = defineEmits(['openSidebar'])
 
@@ -28,22 +29,19 @@ const accountMenuOptions = computed(() => {
     {
       id: 'account',
       label: t('common.shell.account_settings'),
-      icon: 'circle-user',
-      iconStyle: 'fas',
+      icon: faCircleUser,
       action: () => router.push(`${getControllerRoutePrefix()}/account`)
     },
     {
       id: 'theme',
       label: t('common.shell.toggle_theme'),
-      icon: themeStore.isLight ? 'moon' : 'sun',
-      iconStyle: 'fas',
+      icon: themeStore.isLight ? faMoon : faSun,
       action: themeStore.toggleTheme
     },
     {
       id: 'logout',
       label: t('common.shell.sign_out'),
-      icon: 'right-from-bracket',
-      iconStyle: 'fas',
+      icon: faRightFromBracket,
       action: loginStore.logout
     }
   ]

--- a/src/components/controller/units/UnitsTable.vue
+++ b/src/components/controller/units/UnitsTable.vue
@@ -26,7 +26,8 @@ import {
   NeTooltip,
   NeBadge,
   savePreference,
-  useItemPagination
+  useItemPagination,
+  type NeDropdownItem
 } from '@nethesis/vue-components'
 import { type Unit, useUnitsStore } from '@/stores/controller/units'
 import { useDefaultsStore } from '@/stores/controller/defaults'
@@ -37,10 +38,18 @@ import RemoveUnitModal from '@/components/controller/units/RemoveUnitModal.vue'
 import { coerce, outside, satisfies } from 'semver'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import {
+  faArrowsRotate,
+  faArrowUpRightFromSquare,
   faCalendarXmark,
+  faCircleArrowUp,
+  faCircleXmark,
   faClock,
   faCloudArrowUp,
+  faCopy,
+  faPenToSquare,
   faSync,
+  faTerminal,
+  faTrash,
   faWarning
 } from '@fortawesome/free-solid-svg-icons'
 import { library } from '@fortawesome/fontawesome-svg-core'
@@ -124,29 +133,26 @@ async function openUnit(unit: Unit, versionCheck = true) {
 }
 
 function getKebabMenuItems(unit: Unit) {
-  const menuItems: Array<any> = []
+  const menuItems: Array<NeDropdownItem> = []
   if (unit.registered) {
     menuItems.push(
       {
         id: 'openMetrics',
         label: t('controller.units.open_metrics'),
-        icon: 'arrow-up-right-from-square',
-        iconStyle: 'fas',
+        icon: faArrowUpRightFromSquare,
         action: () => openMetrics(unit)
       },
       {
         id: 'openLogs',
         label: t('controller.units.open_logs'),
-        icon: 'arrow-up-right-from-square',
-        iconStyle: 'fas',
+        icon: faArrowUpRightFromSquare,
         action: () => openLogs(unit),
         disabled: !unit.info.fqdn
       },
       {
         id: 'openSsh',
         label: t('controller.units.open_ssh_terminal'),
-        icon: 'terminal',
-        iconStyle: 'fas',
+        icon: faTerminal,
         action: () => emit('openSshModal', unit),
         disabled: !unit.connected
       }
@@ -155,8 +161,7 @@ function getKebabMenuItems(unit: Unit) {
     menuItems.push({
       id: 'copyJoinCode',
       label: t('controller.units.copy_join_code'),
-      icon: 'copy',
-      iconStyle: 'fas',
+      icon: faCopy,
       action: () => copyJoinCode(unit)
     })
   }
@@ -167,8 +172,7 @@ function getKebabMenuItems(unit: Unit) {
         unit.info.scheduled_update > 0
           ? t('controller.units.edit_scheduled_image_update')
           : t('standalone.update.update_system'),
-      icon: unit.info.scheduled_update > 0 ? 'pen-to-square' : 'circle-arrow-up',
-      iconStyle: 'fas',
+      icon: unit.info.scheduled_update > 0 ? faPenToSquare : faCircleArrowUp,
       action: () => emit('scheduleUpdate', unit),
       disabled: !unit.connected || unitsStore.unitUpgradingImage.find((id) => id == unit.id)
     })
@@ -177,8 +181,7 @@ function getKebabMenuItems(unit: Unit) {
     menuItems.push({
       id: 'cancelScheduledUpdate',
       label: t('controller.units.cancel_scheduled_image_update'),
-      icon: 'circle-xmark',
-      iconStyle: 'fas',
+      icon: faCircleXmark,
       action: () => emit('abortUpdate', unit),
       disabled: !unit.connected
     })
@@ -188,16 +191,14 @@ function getKebabMenuItems(unit: Unit) {
     {
       id: 'upgradeUnitPackages',
       label: t('controller.units.check_packages_updates'),
-      icon: 'arrows-rotate',
-      iconStyle: 'fas',
+      icon: faArrowsRotate,
       action: () => emit('upgradeUnitPackages', unit),
       disabled: !unit.connected || unitsStore.unitUpdatingPackages.find((id) => id == unit.id)
     },
     {
       id: 'refreshUnitInfo',
       label: t('controller.units.sync_unit_info'),
-      icon: 'cloud-arrow-up',
-      iconStyle: 'fas',
+      icon: faCloudArrowUp,
       action: () => refreshUnitInfo(unit),
       disabled: !unit.connected
     },
@@ -207,8 +208,7 @@ function getKebabMenuItems(unit: Unit) {
     {
       id: 'removeUnit',
       label: t('controller.units.remove_unit'),
-      icon: 'trash',
-      iconStyle: 'fas',
+      icon: faTrash,
       action: () => maybeShowRemoveUnitModal(unit),
       danger: true
     }

--- a/src/components/controller/users/UsersTable.vue
+++ b/src/components/controller/users/UsersTable.vue
@@ -21,7 +21,7 @@ import { type ControllerAccount } from '@/stores/controller/accounts'
 import { useLoginStore } from '@/stores/controller/controllerLogin'
 import { ref } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { faCircleCheck, faCircleXmark } from '@fortawesome/free-solid-svg-icons'
+import { faCircleCheck, faCircleXmark, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const props = defineProps<{
   users: ControllerAccount[]
@@ -44,8 +44,7 @@ function getDropdownItems(item: ControllerAccount) {
     {
       id: 'delete',
       label: t('common.delete'),
-      iconStyle: 'fas',
-      icon: 'trash',
+      icon: faTrash,
       danger: true,
       action: () => {
         emit('delete', item)

--- a/src/components/standalone/StandaloneTopBar.vue
+++ b/src/components/standalone/StandaloneTopBar.vue
@@ -16,6 +16,7 @@ import { isEmpty, isEqual } from 'lodash-es'
 import { ubusCall } from '@/lib/standalone/ubus'
 import { isStandaloneMode } from '@/lib/config'
 import UciChangesModal from './UciChangesModal.vue'
+import { faCircleUser, faMoon, faRightFromBracket, faSun } from '@fortawesome/free-solid-svg-icons'
 
 const emit = defineEmits(['openSidebar'])
 
@@ -41,23 +42,20 @@ const accountMenuOptions = computed(() => {
     {
       id: 'account',
       label: t('common.shell.account_settings'),
-      icon: 'circle-user',
-      iconStyle: 'fas',
+      icon: faCircleUser,
       action: () => router.push('/standalone/account'),
       disabled: !isStandaloneMode()
     },
     {
       id: 'theme',
       label: t('common.shell.toggle_theme'),
-      icon: themeStore.isLight ? 'moon' : 'sun',
-      iconStyle: 'fas',
+      icon: themeStore.isLight ? faMoon : faSun,
       action: themeStore.toggleTheme
     },
     {
       id: 'logout',
       label: t('common.shell.sign_out'),
-      icon: 'right-from-bracket',
-      iconStyle: 'fas',
+      icon: faRightFromBracket,
       action: loginStore.logout,
       disabled: !isStandaloneMode()
     }

--- a/src/components/standalone/backup_and_restore/BackupContent.vue
+++ b/src/components/standalone/backup_and_restore/BackupContent.vue
@@ -39,6 +39,7 @@ import {
   faEdit,
   faLock,
   faPlay,
+  faTrash,
   faUnlock
 } from '@fortawesome/free-solid-svg-icons'
 import { useBackupsStore } from '@/stores/standalone/backups.ts'
@@ -181,8 +182,7 @@ function getDropdownItems(item: Backup) {
     {
       id: 'delete',
       label: t('common.delete'),
-      iconStyle: 'fas',
-      icon: 'trash',
+      icon: faTrash,
       danger: true,
       action: () => {
         openDeleteBackup(

--- a/src/components/standalone/certificates/CertificatesTable.vue
+++ b/src/components/standalone/certificates/CertificatesTable.vue
@@ -23,6 +23,7 @@ import {
 } from '@nethesis/vue-components'
 import type { Certificate } from '@/views/standalone/system/CertificatesView.vue'
 import { ref } from 'vue'
+import { faCircleCheck, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 
@@ -99,9 +100,8 @@ function getDropdownItems(item: Certificate) {
     {
       id: 'set_as_default',
       label: t('standalone.certificates.set_as_default'),
-      iconStyle: 'fas',
       disabled: isCertificateExpired(item) || item.pending,
-      icon: 'circle-check',
+      icon: faCircleCheck,
       action: () => {
         emit('setAsDefault', item)
       }
@@ -112,8 +112,7 @@ function getDropdownItems(item: Certificate) {
           {
             id: 'delete',
             label: t('common.delete'),
-            iconStyle: 'fas',
-            icon: 'trash',
+            icon: faTrash,
             danger: true,
             action: () => {
               emit('delete', item)

--- a/src/components/standalone/dns_dhcp/DnsRecordsTable.vue
+++ b/src/components/standalone/dns_dhcp/DnsRecordsTable.vue
@@ -9,6 +9,7 @@ import NeTable from '../NeTable.vue'
 import { NeDropdown } from '@nethesis/vue-components'
 import { NeButton } from '@nethesis/vue-components'
 import type { DnsRecord } from './DnsRecords.vue'
+import { faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 
@@ -46,8 +47,7 @@ function getDropdownItems(item: DnsRecord) {
     {
       id: 'delete',
       label: t('common.delete'),
-      iconStyle: 'fas',
-      icon: 'trash',
+      icon: faTrash,
       danger: true,
       action: () => {
         emit('record-delete', item)

--- a/src/components/standalone/dns_dhcp/LeasesTable.vue
+++ b/src/components/standalone/dns_dhcp/LeasesTable.vue
@@ -17,6 +17,7 @@ import {
 import type { StaticLease } from './StaticLeases.vue'
 import type { DynamicLease } from './DynamicLeases.vue'
 import { ref } from 'vue'
+import { faCirclePlus, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 
@@ -63,8 +64,7 @@ function getDropdownItems(item: StaticLease) {
         {
           id: 'delete',
           label: t('common.delete'),
-          iconStyle: 'fas',
-          icon: 'trash',
+          icon: faTrash,
           danger: true,
           action: () => {
             emit('lease-delete', item)
@@ -75,8 +75,7 @@ function getDropdownItems(item: StaticLease) {
         {
           id: 'create-static-lease',
           label: t('standalone.dns_dhcp.add_reservation'),
-          iconStyle: 'fas',
-          icon: 'circle-plus',
+          icon: faCirclePlus,
           action: () => {
             emit('create-static-lease-from-dynamic', item)
           }

--- a/src/components/standalone/dns_dhcp/ScanResultsTable.vue
+++ b/src/components/standalone/dns_dhcp/ScanResultsTable.vue
@@ -18,6 +18,7 @@ import {
 import { ref, type PropType } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ScanResult } from './ScanNetwork.vue'
+import { faCirclePlus } from '@fortawesome/free-solid-svg-icons'
 
 const props = defineProps({
   results: {
@@ -43,15 +44,13 @@ function getKebabMenuItems(scanResult: ScanResult) {
     {
       id: 'addIpReservation',
       label: t('standalone.dns_dhcp.add_reservation'),
-      icon: 'circle-plus',
-      iconStyle: 'fas',
+      icon: faCirclePlus,
       action: () => emit('addIpReservation', scanResult)
     },
     {
       id: 'addDnsRecord',
       label: t('standalone.dns_dhcp.add_dns_record'),
-      icon: 'circle-plus',
-      iconStyle: 'fas',
+      icon: faCirclePlus,
       action: () => emit('addDnsRecord', scanResult)
     }
   ]

--- a/src/components/standalone/dpi/DpiExceptionCard.vue
+++ b/src/components/standalone/dpi/DpiExceptionCard.vue
@@ -8,6 +8,7 @@ import { useI18n } from 'vue-i18n'
 import type { DpiException } from './DpiExceptions.vue'
 import { NeCard } from '@nethesis/vue-components'
 import { NeButton } from '@nethesis/vue-components'
+import { faTrash } from '@fortawesome/free-solid-svg-icons'
 
 defineProps<{
   exception: DpiException
@@ -27,8 +28,7 @@ const emit = defineEmits<{
       {
         id: 'delete',
         label: t('common.delete'),
-        icon: 'trash',
-        iconStyle: 'fas',
+        icon: faTrash,
         action: () => emit('delete', exception),
         danger: true
       }

--- a/src/components/standalone/dpi/DpiRuleCard.vue
+++ b/src/components/standalone/dpi/DpiRuleCard.vue
@@ -11,6 +11,7 @@ import { getZoneBorderColorClasses } from '@/lib/standalone/network'
 import { computed, ref } from 'vue'
 import { ubusCall } from '@/lib/standalone/ubus'
 import type { Zone } from '@/stores/standalone/firewall'
+import { faCircleCheck, faCircleXmark, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 interface Props {
   rule: DpiRule
@@ -87,15 +88,13 @@ async function toggleRule() {
       {
         id: 'enable_disable',
         label: rule.enabled ? t('common.disable') : t('common.enable'),
-        iconStyle: 'fas',
-        icon: rule.enabled ? 'circle-xmark' : 'circle-check',
+        icon: rule.enabled ? faCircleXmark : faCircleCheck,
         action: () => toggleRule()
       },
       {
         id: 'delete',
         label: t('common.delete'),
-        icon: 'trash',
-        iconStyle: 'fas',
+        icon: faTrash,
         action: () => emit('deleteRule', rule),
         danger: true
       }

--- a/src/components/standalone/firewall/PortForwardTable.vue
+++ b/src/components/standalone/firewall/PortForwardTable.vue
@@ -18,6 +18,7 @@ import {
   NeButton
 } from '@nethesis/vue-components'
 import ObjectTooltip from '@/components/standalone/users_objects/ObjectTooltip.vue'
+import { faCircleCheck, faCircleXmark, faClone, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 
@@ -42,8 +43,7 @@ function getDropdownItems(item: PortForward) {
       label: item.enabled
         ? t('standalone.port_forward.disable')
         : t('standalone.port_forward.enable'),
-      iconStyle: 'fas',
-      icon: item.enabled ? 'circle-xmark' : 'circle-check',
+      icon: item.enabled ? faCircleXmark : faCircleCheck,
       action: () => {
         emit('port-forward-toggle-enable', item)
       }
@@ -51,8 +51,7 @@ function getDropdownItems(item: PortForward) {
     {
       id: 'duplicate',
       label: t('standalone.port_forward.duplicate'),
-      iconStyle: 'fas',
-      icon: 'clone',
+      icon: faClone,
       action: () => {
         emit('port-forward-duplicate', item)
       }
@@ -60,8 +59,7 @@ function getDropdownItems(item: PortForward) {
     {
       id: 'delete',
       label: t('common.delete'),
-      iconStyle: 'fas',
-      icon: 'trash',
+      icon: faTrash,
       danger: true,
       action: () => {
         emit('port-forward-delete', item)

--- a/src/components/standalone/firewall/nat/NatRulesTable.vue
+++ b/src/components/standalone/firewall/nat/NatRulesTable.vue
@@ -21,6 +21,7 @@ import {
 import { ref, type PropType } from 'vue'
 import { type NatRule } from '@/stores/standalone/firewall'
 import { getZoneColorClasses } from '@/lib/standalone/network'
+import { faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const props = defineProps({
   rules: {
@@ -46,8 +47,7 @@ function getDropdownItems(rule: NatRule) {
     {
       id: 'delete',
       label: t('common.delete'),
-      icon: 'trash',
-      iconStyle: 'fas',
+      icon: faTrash,
       action: () => emit('deleteRule', rule),
       danger: true
     }

--- a/src/components/standalone/firewall/nat/NetmapTable.vue
+++ b/src/components/standalone/firewall/nat/NetmapTable.vue
@@ -10,6 +10,7 @@ import { NeDropdown } from '@nethesis/vue-components'
 import { computed, type PropType } from 'vue'
 import NeTable from '@/components/standalone/NeTable.vue'
 import { type NetmapRule } from '@/stores/standalone/firewall'
+import { faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const props = defineProps({
   rules: {
@@ -76,8 +77,7 @@ function getDropdownItems(rule: NetmapRule) {
     {
       id: 'delete',
       label: t('common.delete'),
-      icon: 'trash',
-      iconStyle: 'fas',
+      icon: faTrash,
       action: () => emit('deleteRule', rule),
       danger: true
     }

--- a/src/components/standalone/firewall/rules/FirewallRulesTable.vue
+++ b/src/components/standalone/firewall/rules/FirewallRulesTable.vue
@@ -12,7 +12,13 @@ import NeTable from '@/components/standalone/NeTable.vue'
 import { isEmpty } from 'lodash-es'
 import { type FirewallRule, type RuleType } from '@/stores/standalone/firewall'
 import SourceOrDestinationRuleColumn from './SourceOrDestinationRuleColumn.vue'
-import { faGripVertical } from '@fortawesome/free-solid-svg-icons'
+import {
+  faCircleCheck,
+  faCircleXmark,
+  faCopy,
+  faGripVertical,
+  faTrash
+} from '@fortawesome/free-solid-svg-icons'
 import { useHostSets } from '@/composables/useHostSets'
 import { useDomainSets } from '@/composables/useDomainSets'
 
@@ -149,22 +155,19 @@ function getRuleKebabMenuItems(rule: FirewallRule) {
     {
       id: 'enableOrDisable',
       label: rule.enabled ? t('common.disable') : t('common.enable'),
-      iconStyle: 'fas',
-      icon: rule.enabled ? 'circle-xmark' : 'circle-check',
+      icon: rule.enabled ? faCircleXmark : faCircleCheck,
       action: () => emit('toggleRule', rule)
     },
     {
       id: 'duplicate',
       label: t('standalone.firewall_rules.duplicate'),
-      icon: 'copy',
-      iconStyle: 'fas',
+      icon: faCopy,
       action: () => emit('duplicateRule', rule)
     },
     {
       id: 'delete',
       label: t('common.delete'),
-      icon: 'trash',
-      iconStyle: 'fas',
+      icon: faTrash,
       action: () => emit('deleteRule', rule),
       danger: true
     }

--- a/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
+++ b/src/components/standalone/interfaces_and_devices/ConfigureDeviceDrawer.vue
@@ -5,10 +5,10 @@
 
 <script setup lang="ts">
 import {
+  getIconFromZone,
   getInterface,
   getName,
   getZoneColor,
-  getZoneIcon,
   isBond,
   isBridge,
   isUnconfiguredBond
@@ -221,7 +221,7 @@ const zoneOptions = computed(() => {
       id: zone.name,
       label: toUpper(zone.name),
       description: getZoneColor(zone.name),
-      icon: getZoneIcon(zone.name)
+      icon: getIconFromZone(zone.name)
     }
   })
 })

--- a/src/components/standalone/interfaces_and_devices/DeviceButtons.vue
+++ b/src/components/standalone/interfaces_and_devices/DeviceButtons.vue
@@ -13,6 +13,7 @@ import {
 } from '@/lib/standalone/network'
 import type { PropType } from 'vue'
 import { NeDropdown, NeButton } from '@nethesis/vue-components'
+import { faCircleMinus, faCopy, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 
@@ -47,8 +48,7 @@ function getConfiguredDeviceKebabMenuItems(device: DeviceOrIface) {
     {
       id: 'createAliasInterface',
       label: t('standalone.interfaces_and_devices.create_alias_interface'),
-      icon: 'copy',
-      iconStyle: 'fas',
+      icon: faCopy,
       action: () => emit('showCreateAliasInterfaceDrawer', device),
       disabled:
         !iface ||
@@ -60,8 +60,7 @@ function getConfiguredDeviceKebabMenuItems(device: DeviceOrIface) {
       label: isBridge(device)
         ? t('standalone.interfaces_and_devices.delete_interface')
         : t('standalone.interfaces_and_devices.remove_configuration'),
-      icon: 'circle-minus',
-      iconStyle: 'fas',
+      icon: faCircleMinus,
       action: () => emit('showUnconfigureDeviceModal', device),
       danger: true,
       disabled: !iface
@@ -74,8 +73,7 @@ function getUnconfiguredVlanKebabMenuItems(device: DeviceOrIface) {
     {
       id: 'deleteDevice',
       label: t('standalone.interfaces_and_devices.delete_device'),
-      icon: 'trash',
-      iconStyle: 'fas',
+      icon: faTrash,
       action: () => emit('showDeleteDeviceModal', device),
       danger: true
     }
@@ -133,8 +131,7 @@ function getUnconfiguredVlanKebabMenuItems(device: DeviceOrIface) {
       {
         id: 'deleteBond',
         label: t('standalone.interfaces_and_devices.delete_bond'),
-        icon: 'trash',
-        iconStyle: 'fas',
+        icon: faTrash,
         action: () => emit('showDeleteBondModal', deviceOrIface),
         danger: true
       }

--- a/src/components/standalone/ipsec_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/ipsec_tunnel/CreateOrEditTunnelDrawer.vue
@@ -35,6 +35,7 @@ import {
 import { ubusCall } from '@/lib/standalone/ubus'
 import NeMultiTextInput from '../NeMultiTextInput.vue'
 import NeCopyField from '../NeCopyField.vue'
+import { faCircleArrowUp, faKey } from '@fortawesome/free-solid-svg-icons'
 
 const props = defineProps<{
   isShown: boolean
@@ -134,12 +135,12 @@ const presharedKeyOptions = [
   {
     id: 'generate',
     label: t('standalone.ipsec_tunnel.use_generated_key'),
-    icon: 'key'
+    icon: faKey
   },
   {
     id: 'import',
     label: t('standalone.ipsec_tunnel.use_custom_key'),
-    icon: 'circle-arrow-up'
+    icon: faCircleArrowUp
   }
 ]
 const wanOptions = ref<NeComboboxOption[]>([])

--- a/src/components/standalone/ipsec_tunnel/TunnelTable.vue
+++ b/src/components/standalone/ipsec_tunnel/TunnelTable.vue
@@ -9,6 +9,7 @@ import NeTable from '../NeTable.vue'
 import { NeDropdown } from '@nethesis/vue-components'
 import { NeButton } from '@nethesis/vue-components'
 import type { IpsecTunnel } from '@/views/standalone/vpn/IPsecTunnelView.vue'
+import { faCircleCheck, faCircleXmark, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 
@@ -53,8 +54,7 @@ function getDropdownItems(item: IpsecTunnel) {
         item.enabled === '1'
           ? t('standalone.ipsec_tunnel.disable')
           : t('standalone.ipsec_tunnel.enable'),
-      iconStyle: 'fas',
-      icon: item.enabled === '1' ? 'circle-xmark' : 'circle-check',
+      icon: item.enabled === '1' ? faCircleXmark : faCircleCheck,
       action: () => {
         emit('tunnel-toggle-enable', item)
       }
@@ -62,8 +62,7 @@ function getDropdownItems(item: IpsecTunnel) {
     {
       id: 'delete',
       label: t('common.delete'),
-      iconStyle: 'fas',
-      icon: 'trash',
+      icon: faTrash,
       danger: true,
       action: () => {
         emit('tunnel-delete', item)

--- a/src/components/standalone/openvpn_rw/RWAccountsTable.vue
+++ b/src/components/standalone/openvpn_rw/RWAccountsTable.vue
@@ -23,6 +23,13 @@ import type {
   RWAccount
 } from '@/views/standalone/vpn/OpenvpnRoadWarriorView.vue'
 import { ref } from 'vue'
+import {
+  faArrowsRotate,
+  faCircleArrowDown,
+  faCircleCheck,
+  faCircleXmark,
+  faTrash
+} from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 
@@ -51,8 +58,7 @@ function getDropdownItems(item: RWAccount) {
     {
       id: 'download_configuration',
       label: t('standalone.openvpn_rw.download_configuration'),
-      iconStyle: 'fas',
-      icon: 'circle-arrow-down',
+      icon: faCircleArrowDown,
       danger: false,
       action: () => {
         emit('downloadConfiguration', item)
@@ -61,8 +67,7 @@ function getDropdownItems(item: RWAccount) {
     {
       id: 'download_certificate',
       label: t('standalone.openvpn_rw.download_certificate'),
-      iconStyle: 'fas',
-      icon: 'circle-arrow-down',
+      icon: faCircleArrowDown,
       danger: false,
       action: () => {
         emit('downloadCertificate', item)
@@ -73,8 +78,7 @@ function getDropdownItems(item: RWAccount) {
           {
             id: 'download_qr_code',
             label: t('standalone.openvpn_rw.download_qr_code'),
-            iconStyle: 'fas',
-            icon: 'circle-arrow-down',
+            icon: faCircleArrowDown,
             danger: false,
             action: () => {
               emit('downloadQrCode', item)
@@ -85,8 +89,7 @@ function getDropdownItems(item: RWAccount) {
     {
       id: 'enable_disable',
       label: item.openvpn_enabled === '1' ? t('common.disable') : t('common.enable'),
-      iconStyle: 'fas',
-      icon: item.openvpn_enabled === '1' ? 'circle-xmark' : 'circle-check',
+      icon: item.openvpn_enabled === '1' ? faCircleXmark : faCircleCheck,
       action: () => {
         emit('enableDisable', item)
       }
@@ -94,8 +97,7 @@ function getDropdownItems(item: RWAccount) {
     {
       id: 'regenerate_certificate',
       label: t('standalone.openvpn_rw.regenerate_certificate'),
-      iconStyle: 'fas',
-      icon: 'arrows-rotate',
+      icon: faArrowsRotate,
       danger: false,
       action: () => {
         emit('regenerateCertificate', item)
@@ -104,8 +106,7 @@ function getDropdownItems(item: RWAccount) {
     {
       id: 'delete',
       label: t('common.delete'),
-      iconStyle: 'fas',
-      icon: 'trash',
+      icon: faTrash,
       danger: true,
       action: () => {
         emit('delete', item)

--- a/src/components/standalone/openvpn_rw/RWServerDetails.vue
+++ b/src/components/standalone/openvpn_rw/RWServerDetails.vue
@@ -8,6 +8,7 @@ import { useI18n } from 'vue-i18n'
 import { NeDropdown } from '@nethesis/vue-components'
 import { NeButton } from '@nethesis/vue-components'
 import type { RWServer } from '@/views/standalone/vpn/OpenvpnRoadWarriorView.vue'
+import { faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 
@@ -86,8 +87,7 @@ const emit = defineEmits(['delete-server', 'edit-server'])
             {
               id: 'delete',
               label: t('common.delete'),
-              iconStyle: 'fas',
-              icon: 'trash',
+              icon: faTrash,
               danger: true,
               action: () => {
                 emit('delete-server')

--- a/src/components/standalone/openvpn_tunnel/TunnelTable.vue
+++ b/src/components/standalone/openvpn_tunnel/TunnelTable.vue
@@ -9,6 +9,12 @@ import NeTable from '../NeTable.vue'
 import { NeDropdown } from '@nethesis/vue-components'
 import { NeButton } from '@nethesis/vue-components'
 import type { ServerTunnel, ClientTunnel } from './TunnelManager.vue'
+import {
+  faCircleArrowDown,
+  faCircleCheck,
+  faCircleXmark,
+  faTrash
+} from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 
@@ -90,8 +96,7 @@ function getDropdownItems(item: ServerTunnel) {
     {
       id: 'download',
       label: t('standalone.openvpn_tunnel.download'),
-      iconStyle: 'fas',
-      icon: 'circle-arrow-down',
+      icon: faCircleArrowDown,
       action: () => {
         emit('tunnel-download', item)
       }
@@ -101,8 +106,7 @@ function getDropdownItems(item: ServerTunnel) {
       label: item.enabled
         ? t('standalone.openvpn_tunnel.disable')
         : t('standalone.openvpn_tunnel.enable'),
-      iconStyle: 'fas',
-      icon: item.enabled ? 'circle-xmark' : 'circle-check',
+      icon: item.enabled ? faCircleXmark : faCircleCheck,
       action: () => {
         emit('tunnel-toggle-enable', item)
       }
@@ -110,8 +114,7 @@ function getDropdownItems(item: ServerTunnel) {
     {
       id: 'delete',
       label: t('common.delete'),
-      iconStyle: 'fas',
-      icon: 'trash',
+      icon: faTrash,
       danger: true,
       action: () => {
         emit('tunnel-delete', item)

--- a/src/components/standalone/qos/QoSInterfaceTable.vue
+++ b/src/components/standalone/qos/QoSInterfaceTable.vue
@@ -15,6 +15,7 @@ import {
   getZoneIconForegroundStyle,
   getZoneIconBackgroundStyle
 } from '@/lib/standalone/network'
+import { faCircleCheck, faCircleXmark, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 
@@ -57,8 +58,7 @@ function getDropdownItems(item: QoSInterface) {
     {
       id: 'enable_disable',
       label: !item.disabled ? t('common.disable') : t('common.enable'),
-      iconStyle: 'fas',
-      icon: !item.disabled ? 'circle-xmark' : 'circle-check',
+      icon: !item.disabled ? faCircleXmark : faCircleCheck,
       action: () => {
         emit('enableDisable', item)
       }
@@ -66,8 +66,7 @@ function getDropdownItems(item: QoSInterface) {
     {
       id: 'delete',
       label: t('common.delete'),
-      iconStyle: 'fas',
-      icon: 'trash',
+      icon: faTrash,
       danger: true,
       action: () => {
         emit('delete', item)

--- a/src/components/standalone/reverse_proxy/ProxyTable.vue
+++ b/src/components/standalone/reverse_proxy/ProxyTable.vue
@@ -9,6 +9,7 @@ import NeTable from '../NeTable.vue'
 import { NeDropdown } from '@nethesis/vue-components'
 import { NeButton } from '@nethesis/vue-components'
 import type { ReverseProxy } from '@/views/standalone/network/ReverseProxyView.vue'
+import { faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 
@@ -49,8 +50,7 @@ function getDropdownItems(item: ReverseProxy) {
     {
       id: 'delete',
       label: t('common.delete'),
-      iconStyle: 'fas',
-      icon: 'trash',
+      icon: faTrash,
       danger: true,
       action: () => {
         emit('delete', item)

--- a/src/components/standalone/routes/RoutesContent.vue
+++ b/src/components/standalone/routes/RoutesContent.vue
@@ -30,7 +30,8 @@ import {
   faEarthAmerica,
   faLocationDot,
   faCircleCheck,
-  faCircleXmark
+  faCircleXmark,
+  faTrash
 } from '@fortawesome/free-solid-svg-icons'
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
 import { ubusCall } from '@/lib/standalone/ubus'
@@ -344,7 +345,7 @@ function scrollToMainTable() {
                         danger: true,
                         label: t('common.delete'),
                         disabled: item.readonly,
-                        icon: 'trash',
+                        icon: faTrash,
                         action: () => {
                           deleteRouteId = item.id
                           deleteRouteName = item.ns_description || item.target

--- a/src/components/standalone/security/ips/IpsDisabledRules.vue
+++ b/src/components/standalone/security/ips/IpsDisabledRules.vue
@@ -28,7 +28,7 @@ import {
   useSort
 } from '@nethesis/vue-components'
 import type { AxiosResponse } from 'axios'
-import { faCircleInfo, faShield, faXmarkCircle } from '@fortawesome/free-solid-svg-icons'
+import { faCircleInfo, faShield, faTrash, faXmarkCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import IpsDisableRuleDrawer from '@/components/standalone/security/ips/IpsDisableRuleDrawer.vue'
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
@@ -107,8 +107,7 @@ function dropDownActions(rule: Rule): NeDropdownItem[] {
     {
       id: 'delete',
       label: t('common.delete'),
-      icon: 'trash',
-      iconStyle: 'fas',
+      icon: faTrash,
       danger: true,
       action: () => {
         ruleToEnable.value = rule

--- a/src/components/standalone/security/ips/IpsEventList.vue
+++ b/src/components/standalone/security/ips/IpsEventList.vue
@@ -37,6 +37,8 @@ import {
   faArrowRight,
   faBan,
   faCircleInfo,
+  faCircleXmark,
+  faEyeSlash,
   faShield,
   faWarning
 } from '@fortawesome/free-solid-svg-icons'
@@ -151,8 +153,7 @@ function dropDownActions(item: Event): NeDropdownItem[] {
     {
       id: 'disable-rule',
       label: t('standalone.ips.disable_rule'),
-      icon: 'circle-xmark',
-      iconStyle: 'fas',
+      icon: faCircleXmark,
       action: () => {
         ruleToDisable.value = {
           gid: item.gid.toString(),
@@ -164,8 +165,7 @@ function dropDownActions(item: Event): NeDropdownItem[] {
     {
       id: 'source-suppress-alert',
       label: t('standalone.ips.source_suppress_alert'),
-      icon: 'eye-slash',
-      iconStyle: 'fas',
+      icon: faEyeSlash,
       action: () => {
         alertToSuppress.value = {
           gid: item.gid.toString(),
@@ -179,8 +179,7 @@ function dropDownActions(item: Event): NeDropdownItem[] {
     {
       id: 'destination-suppress-alert',
       label: t('standalone.ips.destination_suppress_alert'),
-      icon: 'eye-slash',
-      iconStyle: 'fas',
+      icon: faEyeSlash,
       action: () => {
         alertToSuppress.value = {
           gid: item.gid.toString(),

--- a/src/components/standalone/security/ips/IpsFilterBypass.vue
+++ b/src/components/standalone/security/ips/IpsFilterBypass.vue
@@ -24,7 +24,7 @@ import {
   useSort
 } from '@nethesis/vue-components'
 import { useI18n } from 'vue-i18n'
-import { faCircleInfo, faCirclePlus, faShield } from '@fortawesome/free-solid-svg-icons'
+import { faCircleInfo, faCirclePlus, faShield, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { computed, onMounted, ref } from 'vue'
 import IpsCreateBypassDrawer from '@/components/standalone/security/ips/IpsCreateBypassDrawer.vue'
@@ -108,8 +108,7 @@ function dropDownActions(bypass: Bypass): NeDropdownItem[] {
     {
       id: 'delete',
       label: t('common.delete'),
-      icon: 'trash',
-      iconStyle: 'fas',
+      icon: faTrash,
       danger: true,
       action: () => {
         bypassToDelete.value = bypass

--- a/src/components/standalone/security/ips/IpsSuppressedAlerts.vue
+++ b/src/components/standalone/security/ips/IpsSuppressedAlerts.vue
@@ -26,7 +26,7 @@ import {
   useItemPagination,
   useSort
 } from '@nethesis/vue-components'
-import { faCircleInfo, faCirclePlus, faShield } from '@fortawesome/free-solid-svg-icons'
+import { faCircleInfo, faCirclePlus, faShield, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { ubusCall } from '@/lib/standalone/ubus'
 import type { AxiosResponse } from 'axios'
@@ -109,8 +109,7 @@ function dropDownActions(suppressedAlert: SuppressedAlert): NeDropdownItem[] {
     {
       id: 'delete',
       label: t('common.delete'),
-      icon: 'trash',
-      iconStyle: 'fas',
+      icon: faTrash,
       danger: true,
       action: () => {
         suppressionToDelete.value = suppressedAlert

--- a/src/components/standalone/security/threat_shield/AddressTable.vue
+++ b/src/components/standalone/security/threat_shield/AddressTable.vue
@@ -19,6 +19,7 @@ import {
 } from '@nethesis/vue-components'
 import type { BanIpLocalAddress } from '@/views/standalone/security/ThreatShieldView.vue'
 import { ref } from 'vue'
+import { faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 
@@ -42,8 +43,7 @@ function getDropdownItems(item: BanIpLocalAddress) {
     {
       id: 'delete',
       label: t('common.delete'),
-      iconStyle: 'fas',
-      icon: 'trash',
+      icon: faTrash,
       danger: true,
       action: () => {
         emit('delete', item)

--- a/src/components/standalone/security/threat_shield_dns/BlockedDomainsTable.vue
+++ b/src/components/standalone/security/threat_shield_dns/BlockedDomainsTable.vue
@@ -20,7 +20,7 @@ import {
 import { ref, type PropType } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { DnsBlockedDomain } from '@/stores/standalone/threatShield'
-import { faCircleInfo, faPenToSquare } from '@fortawesome/free-solid-svg-icons'
+import { faCircleInfo, faPenToSquare, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const props = defineProps({
   filteredDomains: {
@@ -46,8 +46,7 @@ function getKebabMenuItems(domain: DnsBlockedDomain) {
     {
       id: 'deleteHostSet',
       label: t('common.delete'),
-      icon: 'trash',
-      iconStyle: 'fas',
+      icon: faTrash,
       danger: true,
       action: () => emit('deleteDomain', domain),
       disabled: false

--- a/src/components/standalone/security/threat_shield_dns/BypassCard.vue
+++ b/src/components/standalone/security/threat_shield_dns/BypassCard.vue
@@ -6,6 +6,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { NeCard } from '@nethesis/vue-components'
+import { faTrash } from '@fortawesome/free-solid-svg-icons'
 
 defineProps<{
   bypass: string
@@ -24,8 +25,7 @@ const emit = defineEmits<{
       {
         id: 'delete',
         label: t('common.delete'),
-        icon: 'trash',
-        iconStyle: 'fas',
+        icon: faTrash,
         action: () => emit('delete', bypass),
         danger: true
       }

--- a/src/components/standalone/users_database/UsersDatabaseManager.vue
+++ b/src/components/standalone/users_database/UsersDatabaseManager.vue
@@ -26,6 +26,7 @@ import CreateOrEditUserDrawer from './CreateOrEditUserDrawer.vue'
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
 import { CanceledError } from 'axios'
 import { onUnmounted } from 'vue'
+import { faTrash } from '@fortawesome/free-solid-svg-icons'
 
 export type User = {
   local: boolean
@@ -191,8 +192,7 @@ onMounted(() => {
             {
               id: 'delete',
               label: t('common.delete'),
-              iconStyle: 'fas',
-              icon: 'trash',
+              icon: faTrash,
               danger: true,
               action: () => {
                 showDeleteDatabaseModal = true

--- a/src/components/standalone/users_database/UsersTable.vue
+++ b/src/components/standalone/users_database/UsersTable.vue
@@ -19,7 +19,7 @@ import {
   NeTooltip
 } from '@nethesis/vue-components'
 import type { User } from './UsersDatabaseManager.vue'
-import { faCrown } from '@fortawesome/free-solid-svg-icons'
+import { faCircleMinus, faCrown, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { ref } from 'vue'
 
 const props = defineProps<{
@@ -45,8 +45,7 @@ function getDropdownItems(item: User) {
     {
       id: 'delete',
       label: t('common.delete'),
-      iconStyle: 'fas',
-      icon: 'trash',
+      icon: faTrash,
       danger: true,
       action: () => {
         emit('delete', item)
@@ -56,8 +55,7 @@ function getDropdownItems(item: User) {
       ? {
           id: 'remove_admin',
           label: t('standalone.users_database.remove_admin'),
-          iconStyle: 'fas',
-          icon: 'circle-minus',
+          icon: faCircleMinus,
           action: () => {
             emit('removeAdmin', item)
           }
@@ -65,8 +63,7 @@ function getDropdownItems(item: User) {
       : {
           id: 'set_admin',
           label: t('standalone.users_database.set_admin'),
-          iconStyle: 'fas',
-          icon: 'crown',
+          icon: faCrown,
           action: () => {
             emit('setAdmin', item)
           }

--- a/src/components/standalone/users_objects/DomainSetsTable.vue
+++ b/src/components/standalone/users_objects/DomainSetsTable.vue
@@ -20,7 +20,7 @@ import {
 } from '@nethesis/vue-components'
 import { ref, type PropType } from 'vue'
 import { library as faLibrary } from '@fortawesome/fontawesome-svg-core'
-import { faCloud } from '@fortawesome/free-solid-svg-icons'
+import { faCloud, faMagnifyingGlassPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
 import type { DomainSet } from '@/composables/useDomainSets'
 
 const props = defineProps({
@@ -53,16 +53,14 @@ function getKebabMenuItems(domainSet: DomainSet) {
     {
       id: 'showUsagesDomainSet',
       label: t('standalone.objects.show_usages'),
-      icon: 'magnifying-glass-plus',
-      iconStyle: 'fas',
+      icon: faMagnifyingGlassPlus,
       action: () => emit('showUsagesDomainSet', domainSet),
       disabled: !domainSet.used
     },
     {
       id: 'deleteDomainSet',
       label: t('common.delete'),
-      icon: 'trash',
-      iconStyle: 'fas',
+      icon: faTrash,
       danger: true,
       action: () => emit('deleteDomainSet', domainSet)
     }

--- a/src/components/standalone/users_objects/HostSetsTable.vue
+++ b/src/components/standalone/users_objects/HostSetsTable.vue
@@ -24,7 +24,9 @@ import {
   faArrowsLeftRightToLine,
   faAddressCard,
   faDesktop,
-  faBoxArchive
+  faBoxArchive,
+  faMagnifyingGlassPlus,
+  faTrash
 } from '@fortawesome/free-solid-svg-icons'
 import HostSetRecords from './HostSetRecords.vue'
 import { useRouter, useRoute } from 'vue-router'
@@ -71,8 +73,7 @@ function getKebabMenuItems(hostSet: HostSet) {
     {
       id: 'showUsagesHostSet',
       label: t('standalone.objects.show_usages'),
-      icon: 'magnifying-glass-plus',
-      iconStyle: 'fas',
+      icon: faMagnifyingGlassPlus,
       action: () => emit('showUsagesHostSet', hostSet),
       disabled: !hostSet.used,
       danger: false
@@ -83,8 +84,7 @@ function getKebabMenuItems(hostSet: HostSet) {
     kebabItems.push({
       id: 'deleteHostSet',
       label: t('common.delete'),
-      icon: 'trash',
-      iconStyle: 'fas',
+      icon: faTrash,
       danger: true,
       action: () => emit('deleteHostSet', hostSet),
       disabled: false

--- a/src/views/controller/UnitManagerView.vue
+++ b/src/views/controller/UnitManagerView.vue
@@ -29,6 +29,7 @@ import ScheduleUpdateDrawer from '@/components/controller/units/ScheduleUpdateDr
 import AbortUpdateModal from '@/components/controller/units/CancelUpdateModal.vue'
 import UpdateUnitsPackagesModal from '@/components/controller/units/UpdateUnitsPackagesModal.vue'
 import BatchUnitImageUpdate from '@/components/controller/units/BatchUnitImageUpdate.vue'
+import { faArrowsRotate, faCircleMinus, faKey } from '@fortawesome/free-solid-svg-icons'
 
 export type SendOrRevokeAction = 'send' | 'revoke'
 
@@ -136,22 +137,19 @@ function getBulkActionsKebabMenuItems() {
     {
       id: 'scheduleSystemUpdate',
       label: t('standalone.update.update_system', 2),
-      iconStyle: 'fas',
-      icon: 'arrows-rotate',
+      icon: faArrowsRotate,
       action: () => (showBatchUnitImageUpdate.value = true)
     },
     {
       id: 'sendSshKey',
       label: t('controller.units.send_ssh_public_key'),
-      iconStyle: 'fas',
-      icon: 'key',
+      icon: faKey,
       action: () => showSendSshKeyDrawer()
     },
     {
       id: 'revokeSshKey',
       label: t('controller.units.revoke_ssh_public_key'),
-      iconStyle: 'fas',
-      icon: 'circle-minus',
+      icon: faCircleMinus,
       action: () => showRevokeSshKeyDrawer()
     }
   ]

--- a/src/views/standalone/firewall/ZonesAndPolicies.vue
+++ b/src/views/standalone/firewall/ZonesAndPolicies.vue
@@ -33,6 +33,7 @@ import {
   getZoneColorClasses,
   getZoneIcon
 } from '@/lib/standalone/network'
+import { faPenToSquare, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 const firewallConfig = useFirewallStore()
@@ -212,14 +213,14 @@ function editZone(zone: Zone) {
                     id: 'edit',
                     label: t('common.edit'),
                     action: () => editZone(item),
-                    icon: 'pen-to-square'
+                    icon: faPenToSquare
                   },
                   {
                     id: 'delete',
                     danger: true,
                     label: t('common.delete'),
                     action: () => (zoneToDelete = item),
-                    icon: 'trash',
+                    icon: faTrash,
                     disabled: isSpecialZone(item)
                   }
                 ]"

--- a/src/views/standalone/network/InterfacesAndDevicesView.vue
+++ b/src/views/standalone/network/InterfacesAndDevicesView.vue
@@ -59,6 +59,7 @@ import { zonesSorting } from '@/stores/standalone/firewall'
 import DeleteBondModal from '@/components/standalone/interfaces_and_devices/DeleteBondModal.vue'
 import DeviceButtons from '@/components/standalone/interfaces_and_devices/DeviceButtons.vue'
 import type { UciNetworkConfig } from '@/composables/useUciNetworkConfig'
+import { faTrash } from '@fortawesome/free-solid-svg-icons'
 
 const LIST_DEVICES_INTERVAL_TIME = 10000
 const { t, te } = useI18n()
@@ -369,8 +370,7 @@ function getAliasKebabMenuItems(alias: any, device: any) {
     {
       id: 'deleteAlias',
       label: t('standalone.interfaces_and_devices.delete_alias'),
-      icon: 'trash',
-      iconStyle: 'fas',
+      icon: faTrash,
       action: () => showDeleteAliasModal(alias, device),
       danger: true,
       disabled: !getFirewallZone(iface, firewallConfig.value)

--- a/src/views/standalone/system/StorageView.vue
+++ b/src/views/standalone/system/StorageView.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { ubusCall } from '@/lib/standalone/ubus'
+import { faDatabase, faHardDrive } from '@fortawesome/free-solid-svg-icons'
 import {
   NeHeading,
   NeInlineNotification,
@@ -42,7 +43,7 @@ const deviceOptions = computed(() =>
   availableDevices.value.map((storage) => ({
     id: storage.path!,
     label: storage.name!,
-    icon: storage.type == 'disk' ? 'database' : 'hard-drive',
+    icon: storage.type == 'disk' ? faDatabase : faHardDrive,
     type: storage.type!
   }))
 )


### PR DESCRIPTION
Use `IconDefinition` type instead of `string` for `NeRadioSelection` and `NeDropdown` icons.

See:
- https://github.com/nethesis/vue-components/pull/84