### PR TITLE
fix(dashboard): fixed storage usage bar if is zero

### DIFF
--- a/src/components/standalone/dashboard/SystemInfoCard.vue
+++ b/src/components/standalone/dashboard/SystemInfoCard.vue
@@ -279,7 +279,7 @@ async function getUpdatesStatus() {
             class="my-1"
           />
         </div>
-        <div v-if="dataStorageUsagePerc">
+        <div v-if="freeDataStorage != 0 || totalDataStorage != 0">
           <span class="mr-3 font-semibold">{{ t('standalone.dashboard.storage_usage') }}</span>
           <span>{{
             t('standalone.dashboard.usage_free_of_total', {


### PR DESCRIPTION
If the storage is configured but the usage is 0, the bar doesn't come up on the dashboard.
