### PR TITLE
fix: added info message for DNS setting

### DIFF
--- a/src/components/standalone/security/FlashstartContent.vue
+++ b/src/components/standalone/security/FlashstartContent.vue
@@ -181,6 +181,12 @@ function save() {
         :title="t('error.cannot_retrieve_flashstart_configuration')"
       />
       <form v-else class="space-y-6">
+        <NeInlineNotification
+          v-if="status"
+          kind="info"
+          :title="t('standalone.flashstart.remember_dns_dhcp')"
+          :description="t('standalone.flashstart.remember_dns_dhcp_description')"
+        />
         <NeToggle
           v-model="status"
           :label="statusLabel"

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -1591,7 +1591,9 @@
       "service_type": "Service type",
       "custom_servers": "Custom DNS servers",
       "add_custom_servers": "Add custom DNS server",
-      "custom_server_helper": "Use '/<domain>/<server>' syntax to route only requests for a specific domain to the given server. Use the '/<server>#<port>` syntax if the upstream server does not listen on a standard port."
+      "custom_server_helper": "Use '/{'<'}domain{'>'}/{'<'}server{'>'}' syntax to route only requests for a specific domain to the given server. Use the '/{'<'}server{'>'}#{'<'}port{'>'}` syntax if the upstream server does not listen on a standard port.",
+      "remember_dns_dhcp": "FlashStart service requires explicitly specifying the DNS server via DHCP options.",
+      "remember_dns_dhcp_description": "Go to the DHCP section, under Advanced Settings, and add the following option: 6:dns-server,{'<'}YOUR-USUAL-DNS-SERVER{'>'}. This ensures that clients receive the correct DNS server via DHCP."
     },
     "dpi": {
       "title": "DPI filter",


### PR DESCRIPTION
Due to dnsmasq configuration, prompt flashstart users to set DNS manually.

Closes: https://github.com/NethServer/nethsecurity/issues/1162
