### PR TITLE
feat(ts_dns): add local allowlist

### DIFF
--- a/src/components/standalone/security/threat_shield_dns/AllowedDomainsTable.vue
+++ b/src/components/standalone/security/threat_shield_dns/AllowedDomainsTable.vue
@@ -1,0 +1,133 @@
+<!--
+  Copyright (C) 2025 Nethesis S.r.l.
+  SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import {
+  NeTable,
+  NeTableHead,
+  NeTableHeadCell,
+  NeTableBody,
+  NeTableRow,
+  NeTableCell,
+  NePaginator,
+  useItemPagination,
+  NeButton,
+  NeEmptyState,
+  NeDropdown
+} from '@nethesis/vue-components'
+import { ref, type PropType } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { DnsAllowedDomain } from '@/stores/standalone/threatShield'
+import { faCircleInfo, faPenToSquare, faTrash } from '@fortawesome/free-solid-svg-icons'
+
+const props = defineProps({
+  filteredDomains: {
+    type: Array as PropType<DnsAllowedDomain[]>,
+    required: true
+  },
+  loading: {
+    type: Boolean,
+    required: true
+  }
+})
+
+const emit = defineEmits(['reloadData', 'editDomain', 'deleteDomain', 'clearFilter'])
+
+const { t } = useI18n()
+const pageSize = ref(10)
+const { currentPage, paginatedItems } = useItemPagination(() => props.filteredDomains, {
+  itemsPerPage: pageSize
+})
+
+function getKebabMenuItems(domain: DnsAllowedDomain) {
+  return [
+    {
+      id: 'deleteHostSet',
+      label: t('common.delete'),
+      icon: faTrash,
+      danger: true,
+      action: () => emit('deleteDomain', domain),
+      disabled: false
+    }
+  ]
+}
+</script>
+
+<template>
+  <NeTable
+    :aria-label="t('standalone.threat_shield_dns.blocked_domains')"
+    card-breakpoint="lg"
+    :loading="loading"
+    :skeleton-columns="3"
+    :skeleton-rows="6"
+  >
+    <NeTableHead>
+      <NeTableHeadCell>{{ t('standalone.threat_shield_dns.domain') }}</NeTableHeadCell>
+      <NeTableHeadCell>{{ t('standalone.threat_shield_dns.description') }}</NeTableHeadCell>
+      <NeTableHeadCell>
+        <!-- no header for actions -->
+      </NeTableHeadCell>
+    </NeTableHead>
+    <NeTableBody>
+      <!-- no domains matching filter -->
+      <NeTableRow v-if="!props.filteredDomains.length">
+        <NeTableCell colspan="3">
+          <NeEmptyState
+            :title="t('standalone.threat_shield_dns.no_domain_found')"
+            :description="t('common.try_changing_search_filter')"
+            :icon="faCircleInfo"
+            class="bg-white dark:bg-gray-950"
+          >
+            <NeButton kind="tertiary" @click="emit('clearFilter')">
+              {{ t('common.clear_filter') }}</NeButton
+            >
+          </NeEmptyState>
+        </NeTableCell>
+      </NeTableRow>
+      <NeTableRow v-for="(item, index) in paginatedItems" v-else :key="index">
+        <NeTableCell :data-label="t('standalone.threat_shield_dns.domain')">
+          {{ item.address }}
+        </NeTableCell>
+        <NeTableCell :data-label="t('standalone.threat_shield_dns.description')">
+          {{ item.description || '-' }}
+        </NeTableCell>
+        <NeTableCell :data-label="t('common.actions')">
+          <div class="-ml-2.5 flex gap-2 xl:ml-0 xl:justify-end">
+            <NeButton kind="tertiary" @click="emit('editDomain', item)">
+              <template #prefix>
+                <font-awesome-icon :icon="faPenToSquare" class="h-4 w-4" aria-hidden="true" />
+              </template>
+              {{ t('common.edit') }}
+            </NeButton>
+            <!-- kebab menu -->
+            <NeDropdown :items="getKebabMenuItems(item)" :align-to-right="true" />
+          </div>
+        </NeTableCell>
+      </NeTableRow>
+    </NeTableBody>
+    <template #paginator>
+      <NePaginator
+        :current-page="currentPage"
+        :total-rows="props.filteredDomains.length"
+        :page-size="pageSize"
+        :nav-pagination-label="t('ne_table.pagination')"
+        :next-label="t('ne_table.go_to_next_page')"
+        :previous-label="t('ne_table.go_to_previous_page')"
+        :range-of-total-label="t('ne_table.of')"
+        :page-size-label="t('ne_table.show')"
+        @select-page="
+          (page: number) => {
+            currentPage = page
+          }
+        "
+        @select-page-size="
+          (size: number) => {
+            pageSize = size
+          }
+        "
+      />
+    </template>
+  </NeTable>
+</template>

--- a/src/components/standalone/security/threat_shield_dns/CreateOrEditAllowedDomainDrawer.vue
+++ b/src/components/standalone/security/threat_shield_dns/CreateOrEditAllowedDomainDrawer.vue
@@ -1,0 +1,194 @@
+<!--
+  Copyright (C) 2025 Nethesis S.r.l.
+  SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import {
+  NeInlineNotification,
+  type NeComboboxOption,
+  NeButton,
+  NeSideDrawer,
+  NeTextInput,
+  focusElement
+} from '@nethesis/vue-components'
+import { ref, type PropType, watch } from 'vue'
+import { ValidationError } from '@/lib/standalone/ubus'
+import { MessageBag, validateDomainName, validateRequired } from '@/lib/validation'
+import { useThreatShieldStore, type DnsAllowedDomain } from '@/stores/standalone/threatShield'
+
+const props = defineProps({
+  isShown: { type: Boolean, default: false },
+  currentDomain: {
+    type: Object as PropType<DnsAllowedDomain>
+  },
+  recordOptions: {
+    type: Array as PropType<NeComboboxOption[]>
+  }
+})
+
+const emit = defineEmits(['close', 'reloadData'])
+
+const { t } = useI18n()
+const tsStore = useThreatShieldStore()
+const domain = ref('')
+const domainRef = ref()
+const description = ref('')
+const descriptionRef = ref()
+const errorBag = ref(new MessageBag())
+
+watch(
+  () => props.isShown,
+  () => {
+    if (props.isShown) {
+      clearErrors()
+
+      if (props.currentDomain) {
+        // editing domain
+        domain.value = props.currentDomain.address
+        description.value = props.currentDomain?.description || ''
+        focusElement(descriptionRef)
+      } else {
+        // creating domain, reset form to defaults
+        domain.value = ''
+        description.value = ''
+        focusElement(domainRef)
+      }
+    }
+  }
+)
+
+function closeDrawer() {
+  emit('close')
+}
+
+function clearErrors() {
+  errorBag.value.clear()
+  tsStore.errorSaveDnsAllowedDomain = ''
+  tsStore.errorSaveDnsAllowedDomainDetails = ''
+}
+
+function validate() {
+  clearErrors()
+  let isValidationOk = true
+
+  const requiredValidator = validateRequired(domain.value)
+  if (!requiredValidator.valid) {
+    errorBag.value.set('address', [requiredValidator.errMessage as string])
+    if (isValidationOk) {
+      focusElement(domainRef)
+      isValidationOk = false
+    }
+  } else {
+    const domainValidator = validateDomainName(domain.value)
+    if (!domainValidator.valid) {
+      errorBag.value.set('address', [domainValidator.errMessage as string])
+      if (isValidationOk) {
+        focusElement(domainRef)
+        isValidationOk = false
+      }
+    }
+  }
+  return isValidationOk
+}
+
+async function saveBlockedDomain() {
+  const isValidationOk = validate()
+  if (!isValidationOk) {
+    return
+  }
+
+  const payload: any = {
+    address: domain.value
+  }
+
+  if (description.value) {
+    payload.description = description.value
+  } else {
+    payload.description = ''
+  }
+
+  const isEditing = props.currentDomain ? true : false
+
+  try {
+    await tsStore.saveDnsAllowedDomain(payload, isEditing)
+    emit('reloadData')
+    closeDrawer()
+  } catch (err: any) {
+    console.error(err)
+
+    if (err instanceof ValidationError) {
+      errorBag.value = err.errorBag
+    }
+  }
+}
+</script>
+
+<template>
+  <NeSideDrawer
+    :is-shown="isShown"
+    :title="
+      currentDomain
+        ? t('standalone.threat_shield_dns.edit_domain')
+        : t('standalone.threat_shield_dns.add_domain')
+    "
+    :close-aria-label="t('common.shell.close_side_drawer')"
+    @close="closeDrawer"
+  >
+    <form @submit.prevent>
+      <div class="space-y-6">
+        <!-- domain -->
+        <NeTextInput
+          ref="domainRef"
+          v-model.trim="domain"
+          :label="t('standalone.threat_shield_dns.domain')"
+          :invalid-message="t(errorBag.getFirstI18nKeyFor('address'))"
+          :disabled="tsStore.loadingSaveDnsAllowedDomain || !!currentDomain"
+        />
+        <!-- description -->
+        <NeTextInput
+          ref="descriptionRef"
+          v-model.trim="description"
+          :label="t('standalone.threat_shield_dns.description')"
+          :disabled="tsStore.loadingSaveDnsAllowedDomain"
+          optional
+          :optional-label="t('common.optional')"
+        />
+        <!-- save error -->
+        <NeInlineNotification
+          v-if="tsStore.errorSaveDnsAllowedDomain"
+          kind="error"
+          :title="t('error.cannot_save_blocked_domain')"
+          :description="tsStore.errorSaveDnsAllowedDomain"
+        >
+          <template v-if="tsStore.errorSaveDnsAllowedDomainDetails" #details>
+            {{ tsStore.errorSaveDnsAllowedDomainDetails }}
+          </template>
+        </NeInlineNotification>
+      </div>
+      <!-- footer -->
+      <hr class="my-8 border-gray-200 dark:border-gray-700" />
+      <div class="flex justify-end">
+        <NeButton
+          kind="tertiary"
+          size="lg"
+          :disabled="tsStore.loadingSaveDnsAllowedDomain"
+          class="mr-3"
+          @click.prevent="closeDrawer"
+        >
+          {{ t('common.cancel') }}
+        </NeButton>
+        <NeButton
+          kind="primary"
+          size="lg"
+          :disabled="tsStore.loadingSaveDnsAllowedDomain"
+          :loading="tsStore.loadingSaveDnsAllowedDomain"
+          @click.prevent="saveBlockedDomain"
+        >
+          {{ currentDomain ? t('common.save') : t('standalone.threat_shield_dns.add_domain') }}
+        </NeButton>
+      </div>
+    </form>
+  </NeSideDrawer>
+</template>

--- a/src/components/standalone/security/threat_shield_dns/CreateOrEditBlockedDomainDrawer.vue
+++ b/src/components/standalone/security/threat_shield_dns/CreateOrEditBlockedDomainDrawer.vue
@@ -184,11 +184,7 @@ async function saveBlockedDomain() {
           :loading="tsStore.loadingSaveDnsBlockedDomain"
           @click.prevent="saveBlockedDomain"
         >
-          {{
-            currentDomain
-              ? t('standalone.threat_shield_dns.save_domain')
-              : t('standalone.threat_shield_dns.add_domain')
-          }}
+          {{ currentDomain ? t('common.save') : t('standalone.threat_shield_dns.add_domain') }}
         </NeButton>
       </div>
     </form>

--- a/src/components/standalone/security/threat_shield_dns/FilterBypassPanel.vue
+++ b/src/components/standalone/security/threat_shield_dns/FilterBypassPanel.vue
@@ -172,7 +172,7 @@ function clearFilter() {
     <DeleteModal
       :visible="isShownDeleteBypassModal"
       :title="t('standalone.threat_shield_dns.delete_bypass')"
-      :delete-button-label="t('standalone.threat_shield_dns.delete_bypass')"
+      :delete-button-label="t('common.delete')"
       :error-notification-title="t('error.cannot_delete_bypass')"
       :delete-function="() => tsStore.deleteDnsBypass(currentBypass)"
       @close="isShownDeleteBypassModal = false"

--- a/src/components/standalone/security/threat_shield_dns/LocalAllowlistPanel.vue
+++ b/src/components/standalone/security/threat_shield_dns/LocalAllowlistPanel.vue
@@ -1,0 +1,174 @@
+<!--
+  Copyright (C) 2025 Nethesis S.r.l.
+  SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import {
+  NeBadge,
+  NeButton,
+  NeEmptyState,
+  NeInlineNotification,
+  NeTextInput
+} from '@nethesis/vue-components'
+import { computed, onMounted, ref } from 'vue'
+import DeleteModal from '@/components/DeleteModal.vue'
+import { faCheck, faShield, faCirclePlus } from '@fortawesome/free-solid-svg-icons'
+import { useThreatShieldStore, type DnsAllowedDomain } from '@/stores/standalone/threatShield'
+import TsDisabledEmptyState from './TsDisabledEmptyState.vue'
+import CreateOrEditAllowedDomainDrawer from './CreateOrEditAllowedDomainDrawer.vue'
+import AllowedDomainsTable from './AllowedDomainsTable.vue'
+
+const { t } = useI18n()
+const tsStore = useThreatShieldStore()
+const currentDomain = ref<DnsAllowedDomain | undefined>(undefined)
+const isShownCreateOrEditDomainDrawer = ref(false)
+const isShownDeleteDomainModal = ref(false)
+const textFilter = ref('')
+
+const filteredDomains = computed(() => {
+  if (!textFilter.value) {
+    return tsStore.dnsAllowedDomains
+  }
+
+  return tsStore.dnsAllowedDomains.filter((domain) => {
+    return tsStore.searchStringInDnsAllowedDomain(domain, textFilter.value)
+  })
+})
+
+onMounted(() => {
+  loadData()
+})
+
+function loadData() {
+  tsStore.listDnsAllowedDomains()
+}
+
+function showCreateOrEditAllowedDomainDrawer() {
+  currentDomain.value = undefined
+  isShownCreateOrEditDomainDrawer.value = true
+}
+
+function showEditAllowedDomainDrawer(domain: DnsAllowedDomain) {
+  currentDomain.value = domain
+  isShownCreateOrEditDomainDrawer.value = true
+}
+
+function showDeleteAllowedDomainModal(domain: DnsAllowedDomain) {
+  currentDomain.value = domain
+  isShownDeleteDomainModal.value = true
+}
+
+function clearFilter() {
+  textFilter.value = ''
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-8">
+      <div class="flex flex-col items-start justify-between gap-6 xl:flex-row">
+        <div class="max-w-2xl text-sm font-normal text-gray-500 dark:text-gray-400">
+          <p>
+            {{ t('standalone.threat_shield_dns.local_allowlist_description') }}
+          </p>
+        </div>
+        <NeBadge
+          v-if="tsStore.dnsSettings?.enabled"
+          :icon="faCheck"
+          :text="t('standalone.threat_shield_dns.threat_shield_dns_enabled')"
+          kind="success"
+        />
+      </div>
+    </div>
+    <div class="space-y-6">
+      <!-- dns-list-allowed error notification -->
+      <NeInlineNotification
+        v-if="tsStore.errorListDnsAllowedDomains"
+        kind="error"
+        :title="t('error.cannot_retrieve_allowed_domains')"
+        :description="tsStore.errorListDnsAllowedDomains"
+      >
+        <template v-if="tsStore.errorListDnsAllowedDomainsDetails" #details>
+          {{ tsStore.errorListDnsAllowedDomainsDetails }}
+        </template>
+      </NeInlineNotification>
+      <template v-else>
+        <!-- threat shield is disabled -->
+        <TsDisabledEmptyState
+          v-if="!tsStore.loadingListDnsSettings && !tsStore.dnsSettings?.enabled"
+        />
+        <template v-else>
+          <div
+            v-if="tsStore.dnsAllowedDomains.length && !tsStore.loadingListDnsAllowedDomains"
+            class="flex flex-col-reverse items-start justify-between gap-6 sm:flex-row sm:items-center"
+          >
+            <NeTextInput
+              v-model.trim="textFilter"
+              :placeholder="t('common.filter')"
+              is-search
+              :disabled="
+                tsStore.loadingListDnsAllowedDomains || tsStore.loadingListDnsAllowedDomains
+              "
+              class="max-w-xs sm:max-w-sm"
+            />
+            <NeButton kind="secondary" size="lg" @click="showCreateOrEditAllowedDomainDrawer">
+              <template #prefix>
+                <font-awesome-icon :icon="faCirclePlus" class="h-4 w-4" aria-hidden="true" />
+              </template>
+              {{ t('standalone.threat_shield_dns.add_domain') }}
+            </NeButton>
+          </div>
+          <!-- empty state -->
+          <NeEmptyState
+            v-if="!tsStore.dnsAllowedDomains.length && !tsStore.loadingListDnsAllowedDomains"
+            :title="t('standalone.threat_shield_dns.local_allowlist_is_empty')"
+            :icon="faShield"
+            class="mt-4"
+          >
+            <NeButton kind="primary" size="lg" @click="showCreateOrEditAllowedDomainDrawer">
+              <template #prefix>
+                <font-awesome-icon :icon="faCirclePlus" class="h-4 w-4" aria-hidden="true" />
+              </template>
+              {{ t('standalone.threat_shield_dns.add_domain') }}
+            </NeButton>
+          </NeEmptyState>
+          <!-- allowed domains table -->
+          <AllowedDomainsTable
+            v-else
+            :filtered-domains="filteredDomains"
+            :loading="tsStore.loadingListDnsAllowedDomains"
+            @edit-domain="showEditAllowedDomainDrawer"
+            @delete-domain="showDeleteAllowedDomainModal"
+            @reload-data="loadData"
+            @clear-filters="clearFilter"
+          />
+        </template>
+      </template>
+    </div>
+    <!-- create allowed domain -->
+    <CreateOrEditAllowedDomainDrawer
+      :is-shown="isShownCreateOrEditDomainDrawer"
+      :current-domain="currentDomain"
+      @close="isShownCreateOrEditDomainDrawer = false"
+      @reload-data="loadData"
+    />
+    <!-- delete allowed domain modal -->
+    <DeleteModal
+      :visible="isShownDeleteDomainModal"
+      :title="t('standalone.threat_shield_dns.delete_domain')"
+      :delete-button-label="t('common.delete')"
+      :error-notification-title="t('error.cannot_delete_allowed_domain')"
+      :delete-function="() => tsStore.deleteDnsAllowedDomain(currentDomain?.address || '')"
+      @close="isShownDeleteDomainModal = false"
+      @reload-data="loadData"
+    >
+      {{
+        t('standalone.threat_shield_dns.confirm_delete_allowed_domain', {
+          name: currentDomain?.address
+        })
+      }}
+    </DeleteModal>
+  </div>
+</template>

--- a/src/components/standalone/security/threat_shield_dns/LocalBlocklistPanel.vue
+++ b/src/components/standalone/security/threat_shield_dns/LocalBlocklistPanel.vue
@@ -158,7 +158,7 @@ function clearFilter() {
     <DeleteModal
       :visible="isShownDeleteDomainModal"
       :title="t('standalone.threat_shield_dns.delete_domain')"
-      :delete-button-label="t('standalone.threat_shield_dns.delete_domain')"
+      :delete-button-label="t('common.delete')"
       :error-notification-title="t('error.cannot_delete_blocked_domain')"
       :delete-function="() => tsStore.deleteDnsBlockedDomain(currentDomain?.address || '')"
       @close="isShownDeleteDomainModal = false"

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -1813,7 +1813,15 @@
       "blocked_domain_added_title": "Blocked domain added",
       "blocked_domain_added_description": "'{domain}' has been added to local DNS blocklist",
       "blocked_domain_deleted_title": "Blocked domain deleted",
-      "blocked_domain_deleted_description": "'{domain}' has been deleted from local DNS blocklist"
+      "blocked_domain_deleted_description": "'{domain}' has been deleted from local DNS blocklist",
+      "allowlist": "Local allowlist",
+      "confirm_delete_allowed_domain": "Removing '{name}' may cause it to be blocked if it matches an active blocklist. Are you sure you want to delete it?",
+      "local_allowlist_description": "Always allow content from specific domains. The local allowlist has priority over the local blocklist, meaning that if a domain is present in both lists, it will be allowed.",
+      "allowed_domain_added_title": "Allowed domain added",
+      "allowed_domain_added_description": "'{domain}' has been added to local DNS allowlist",
+      "allowed_domain_deleted_title": "Allowed domain deleted",
+      "allowed_domain_deleted_description": "'{domain}' has been deleted from local DNS allowlist",
+      "local_allowlist_is_empty": "Local allowlist is empty"
     },
     "vpn": {
       "title": "VPN"

--- a/src/views/standalone/security/ThreatShieldDnsView.vue
+++ b/src/views/standalone/security/ThreatShieldDnsView.vue
@@ -18,6 +18,7 @@ import BlocklistSourcesPanel from '@/components/standalone/security/threat_shiel
 import FilterBypassPanel from '@/components/standalone/security/threat_shield_dns/FilterBypassPanel.vue'
 import LocalBlocklistPanel from '@/components/standalone/security/threat_shield_dns/LocalBlocklistPanel.vue'
 import SettingsPanel from '@/components/standalone/security/threat_shield_dns/SettingsPanel.vue'
+import LocalAllowListPanel from '@/components/standalone/security/threat_shield_dns/LocalAllowlistPanel.vue'
 import { onMounted, ref } from 'vue'
 import { useThreatShieldStore } from '@/stores/standalone/threatShield'
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
@@ -39,6 +40,10 @@ const { tabs, selectedTab } = useTabs([
   {
     name: 'filterBypass',
     label: t('standalone.threat_shield_dns.filter_bypass')
+  },
+  {
+    name: 'allowlist',
+    label: t('standalone.threat_shield_dns.allowlist')
   },
   {
     name: 'localBlocklist',
@@ -131,6 +136,7 @@ async function getFlashstartConfig() {
         @select-tab="selectedTab = $event"
       />
       <BlocklistSourcesPanel v-if="selectedTab === 'blocklistSources'" />
+      <LocalAllowListPanel v-if="selectedTab === 'allowlist'" />
       <FilterBypassPanel v-if="selectedTab === 'filterBypass'" />
       <LocalBlocklistPanel v-if="selectedTab === 'localBlocklist'" />
       <SettingsPanel v-if="selectedTab === 'settings'" />


### PR DESCRIPTION
Closes ~~NethServer/nethsecurity#1327~~ https://github.com/NethServer/nethsecurity/issues/1221

Allow CRUD actions on Adblock local allow list

Empty state:
<img width="887" height="606" alt="image" src="https://github.com/user-attachments/assets/339bb941-07a0-48a2-8485-48a3374fe319" />

List:
<img width="887" height="606" alt="image" src="https://github.com/user-attachments/assets/66bec917-aa99-4917-a3e3-94547efbc44b" />

Add:
<img width="889" height="624" alt="image" src="https://github.com/user-attachments/assets/f30b91a9-bf85-4c51-bb3d-939a26e2aadb" />

Edit:
<img width="565" height="371" alt="image" src="https://github.com/user-attachments/assets/16b3e4f6-1a58-47c1-8580-163670e1ee25" />

Delete:
<img width="540" height="240" alt="image" src="https://github.com/user-attachments/assets/3fec3517-e8a4-4d2c-8121-b9a91808b79c" />