### PR TITLE
fix(controller): show selected unit groups

### DIFF
--- a/src/components/controller/users/CreateOrEditUserDrawer.vue
+++ b/src/components/controller/users/CreateOrEditUserDrawer.vue
@@ -68,7 +68,7 @@ async function resetForm() {
     displayName.value = props.itemToEdit.display_name
     isAdmin.value = props.itemToEdit.admin
     unitGroups.value = props.itemToEdit.unit_groups.map<NeComboboxOption>((group: string) => ({
-      id: group,
+      id: String(group),
       label: group,
       description: ''
     }))


### PR DESCRIPTION
Previously, the edit drawer of users was not showing the selected unit groups for a user.

NethServer/nethsecurity#1300