### PR TITLE
fix(controller): minor UI improvements

### DIFF
--- a/src/components/controller/unit_groups/CreateOrEditUnitGroupDrawer.vue
+++ b/src/components/controller/unit_groups/CreateOrEditUnitGroupDrawer.vue
@@ -86,10 +86,6 @@ function validate() {
     focusElement(nameRef)
   }
 
-  if (units.value.length === 0) {
-    validationErrorBag.value.set('units', ['error.required'])
-  }
-
   return validationErrorBag.value.size < 1
 }
 
@@ -192,6 +188,7 @@ watch(
           :multiple="true"
           :optional-label="t('common.optional')"
           :invalid-message="t(validationErrorBag.getFirstI18nKeyFor('units'))"
+          :optional="true"
         />
       </div>
       <hr />

--- a/src/components/controller/units/RemoveUnitModal.vue
+++ b/src/components/controller/units/RemoveUnitModal.vue
@@ -108,6 +108,9 @@ async function removeUnit() {
     @primary-click="removeUnit"
   >
     {{ t('controller.units.confirm_remove_unit', { name: unitName }) }}
+    <div v-if="props.unit?.groups && props.unit.groups.length > 0" class="mt-4">
+      {{ t('controller.units.unit_in_group', { groups: props.unit.groups.join(', ') }) }}
+    </div>
     <NeInlineNotification
       v-if="error.notificationTitle"
       kind="error"

--- a/src/components/controller/units/UnitsTable.vue
+++ b/src/components/controller/units/UnitsTable.vue
@@ -214,8 +214,7 @@ function getKebabMenuItems(unit: Unit) {
         label: t('controller.units.remove_unit'),
         icon: faTrash,
         action: () => maybeShowRemoveUnitModal(unit),
-        danger: true,
-        disabled: (unit.groups?.length ?? 0) > 0
+        danger: true
       }
     )
   }
@@ -266,7 +265,7 @@ function getSubscriptionLabel(subscriptionType: string) {
 }
 
 async function maybeShowRemoveUnitModal(unit: Unit) {
-  if (unit.registered) {
+  if (unit.registered || (unit.groups && unit.groups.length > 0)) {
     showRemoveUnitModal(unit)
   } else {
     await unitsStore.removeUnit(unit.id)

--- a/src/components/controller/users/CreateOrEditUserDrawer.vue
+++ b/src/components/controller/users/CreateOrEditUserDrawer.vue
@@ -299,6 +299,7 @@ watch(
         :user-input-label="t('ne_combobox.user_input_label')"
         :multiple="true"
         :optional-label="t('common.optional')"
+        :optional="true"
         :invalid-message="t(validationErrorBag.getFirstI18nKeyFor('groups'))"
         :tooltip="t('controller.users.unit_groups_tooltip')"
       >

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -2706,7 +2706,7 @@
       "units": "Units",
       "add_unit": "Add unit",
       "remove": "Remove",
-      "used_by": "Used by",
+      "used_by": "Managed by",
       "delete": "Delete unit group",
       "delete_confirm": "You are about to delete the unit group '{name}'. This action cannot be undone.",
       "no_groups_found": "No unit groups found",
@@ -2791,7 +2791,7 @@
       "admin": "Administrator user",
       "admin_tooltip": "This user has administrator privileges and can manage all units and users.",
       "unit_groups": "Unit groups",
-      "unit_groups_tooltip": "Select the unit groups this user can manage. If no groups are selected, the user will not be able access any unit."
+      "unit_groups_tooltip": "Select the unit groups this user can manage. If no groups are selected, the user will not be able to access any unit."
     }
   },
   "notifications": {

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -2656,7 +2656,7 @@
       "subscription_community": "Community subscription",
       "subscription_enterprise": "Enterprise subscription",
       "subscription_none": "No subscription",
-      "confirm_remove_unit": "You are about to remove unit '{name}'. The unit will continue to operate normally, but it will no longer be managed by this Controller.",
+      "confirm_remove_unit": "The unit '{name}' will continue to operate normally, but it will no longer be managed by this Controller.",
       "unit_name_removed": "Unit '{name}' removed",
       "num_units_left": "No units left | {num} unit left | {num} units left",
       "num_units_left_tooltip": "You have configured {num} of {max} units. Upgrade to a subscription plan to manage more units.",
@@ -2692,7 +2692,8 @@
       "updating_image": "Update in progress",
       "updating_image_description": "The unit is updating the image. The unit may be not available for a few minutes while the update is being installed.",
       "groups": "Groups",
-      "description": "Description"
+      "description": "Description",
+      "unit_in_group": "Additionally, it will be removed from the following groups: {groups}"
     },
     "unit_groups": {
       "title": "Unit groups",


### PR DESCRIPTION
**Unit and Unit Group Management Improvements:**

* Made the selection of units optional when creating or editing a unit group by removing the validation requirement and explicitly marking the field as optional in the UI (`CreateOrEditUnitGroupDrawer.vue`) [[1]](diffhunk://#diff-b4044a64e0888c9d2f0a8038e3d7da60342ba9fc7c85e5624770e1dea83542f3L89-L92) [[2]](diffhunk://#diff-b4044a64e0888c9d2f0a8038e3d7da60342ba9fc7c85e5624770e1dea83542f3R191).
* Updated user group selection for users to be explicitly optional in the UI (`CreateOrEditUserDrawer.vue`).

**Unit Removal Flow Enhancements:**

* Changed the logic so that units belonging to groups can now be removed directly, and added a message to inform users that the unit will also be removed from its groups (`UnitsTable.vue`, `RemoveUnitModal.vue`) [[1]](diffhunk://#diff-38808bcf773b3ca1a8d2e0c2895715ad955e622bfbb7505409e8f8f8be5c1948L217-R217) [[2]](diffhunk://#diff-38808bcf773b3ca1a8d2e0c2895715ad955e622bfbb7505409e8f8f8be5c1948L269-R268) [[3]](diffhunk://#diff-7da5c5b984eec206bf3daf418c83686fd02e5cb27a5434cf5f83b6e53ec8ccbeR111-R113).
  
  <img width="533" height="281" alt="image" src="https://github.com/user-attachments/assets/9605830e-21da-4248-8dda-f405eec23431" />

* Updated the unit removal confirmation message and added a new message to clarify removal from groups (`translation.json`) [[1]](diffhunk://#diff-748406503f0dd61aa7860bd36e02a6674aac6247b7e9bbf07dd262966fbaeff0L2659-R2659) [[2]](diffhunk://#diff-748406503f0dd61aa7860bd36e02a6674aac6247b7e9bbf07dd262966fbaeff0L2695-R2696).

**User Interface and Messaging Updates:**

* Improved several English translations for clarity, including the unit removal confirmation, group management tooltips, and other labels (`translation.json`) [[1]](diffhunk://#diff-748406503f0dd61aa7860bd36e02a6674aac6247b7e9bbf07dd262966fbaeff0L2709-R2710) [[2]](diffhunk://#diff-748406503f0dd61aa7860bd36e02a6674aac6247b7e9bbf07dd262966fbaeff0L2794-R2795).