### PR TITLE
fix(ovpn tunnel): change compression alg id

### DIFF
--- a/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
@@ -143,7 +143,7 @@ const compressionOptions = [
     label: t('standalone.openvpn_tunnel.disabled')
   },
   {
-    id: 'lz0',
+    id: 'lzo',
     label: 'LZO'
   },
   {


### PR DESCRIPTION
Change from `lz0` to `lzo`: the `lz0` does not exists.

The algorithm is correct for OpenVPN road warrior.

NethServer/nethsecurity#1357