### PR TITLE
fix(certificates): correctly show not used badge

### DIFF
--- a/src/components/standalone/certificates/CertificatesTable.vue
+++ b/src/components/standalone/certificates/CertificatesTable.vue
@@ -200,7 +200,7 @@ const onSort = (payload: SortEvent) => {
               </template></NeTooltip
             >
             <NeBadge
-              v-if="item.servers?.length ?? 0 <= 0"
+              v-if="(item.servers?.length ?? 0) <= 0"
               kind="secondary"
               class="-mt-0.5"
               :text="t('standalone.certificates.not_used')"

--- a/src/components/standalone/certificates/CertificatesTable.vue
+++ b/src/components/standalone/certificates/CertificatesTable.vue
@@ -200,7 +200,7 @@ const onSort = (payload: SortEvent) => {
               </template></NeTooltip
             >
             <NeBadge
-              v-if="(item.servers?.length ?? 0) <= 0"
+              v-if="!item.servers?.length"
               kind="secondary"
               class="-mt-0.5"
               :text="t('standalone.certificates.not_used')"


### PR DESCRIPTION
The badge was shown even if servers array was not empty

Fixes NethServer/nethsecurity#1353