### PR TITLE
fix(redirects): better destination IP validation

### DIFF
--- a/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
+++ b/src/components/standalone/firewall/CreateOrEditPortForwardDrawer.vue
@@ -436,7 +436,9 @@ function validate(): boolean {
       ? [
           destinationIpRequired
             ? [validateRequired(destinationIP.value), validateIpAddress(destinationIP.value)]
-            : [{ valid: true }],
+            : destinationIP.value
+              ? [validateIpAddress(destinationIP.value)]
+              : [{ valid: true }],
           'destinationIP',
           destinationIpRef
         ]


### PR DESCRIPTION
Make sure the destination IP is always validated,
even if the destination port is set.

Fix NethServer/nethsecurity#1363