### PR TITLE
fix(dhcp): fixed reactivity for filtering

### DIFF
--- a/src/components/standalone/dns_dhcp/LeasesTable.vue
+++ b/src/components/standalone/dns_dhcp/LeasesTable.vue
@@ -52,7 +52,7 @@ function sortAddresses<T extends StaticLease | DynamicLease>(a: T, b: T) {
 }
 
 // Declare sortedItems before useItemPagination
-const { sortedItems } = useSort(props.leases, sortKey, sortDescending, {
+const { sortedItems } = useSort(() => props.leases, sortKey, sortDescending, {
   ipaddr: sortAddresses
 })
 


### PR DESCRIPTION
Spotted an issue where reactivity was not triggering correctly by using non-reactive prop as reactive
