### PR TITLE
feat(openvpn): add tun_mtu and mssfix configuration management for instances

### DIFF
--- a/src/components/standalone/openvpn_rw/CreateOrEditRWServerDrawer.vue
+++ b/src/components/standalone/openvpn_rw/CreateOrEditRWServerDrawer.vue
@@ -14,7 +14,7 @@ import {
   validateRequired,
   type validationOutput,
   validateIp4Address,
-  validateStrictlyPositiveInteger
+  validateIpv4Mtu
 } from '@/lib/validation'
 import {
   NeInlineNotification,
@@ -377,16 +377,8 @@ function validate() {
     [[validateRequired(name.value)], 'ns_description', nameRef],
     [[validateRequired(userDatabase.value)], 'ns_user_db', userDatabaseRef],
     [[validateRequired(port.value), validatePort(port.value)], 'port', portRef],
-    [
-      [validateRequired(tunMtu.value), validateStrictlyPositiveInteger(tunMtu.value)],
-      'tun_mtu',
-      tunMtuRef
-    ],
-    [
-      [validateRequired(mssfix.value), validateStrictlyPositiveInteger(mssfix.value)],
-      'mssfix',
-      mssfixRef
-    ],
+    [[validateRequired(tunMtu.value), validateIpv4Mtu(tunMtu.value)], 'tun_mtu', tunMtuRef],
+    [[validateRequired(mssfix.value), validateIpv4Mtu(mssfix.value)], 'mssfix', mssfixRef],
     ...(mode.value === 'bridged' ? bridgedServerValidators : routedServerValidators)
   ]
 

--- a/src/components/standalone/openvpn_rw/CreateOrEditRWServerDrawer.vue
+++ b/src/components/standalone/openvpn_rw/CreateOrEditRWServerDrawer.vue
@@ -13,7 +13,8 @@ import {
   validatePort,
   validateRequired,
   type validationOutput,
-  validateIp4Address
+  validateIp4Address,
+  validateStrictlyPositiveInteger
 } from '@/lib/validation'
 import {
   NeInlineNotification,
@@ -73,6 +74,10 @@ const publicIpOrHostname = ref<string[]>([])
 const protocol = ref('udp')
 const port = ref('')
 const portRef = ref()
+const tunMtu = ref('')
+const tunMtuRef = ref()
+const mssfix = ref('')
+const mssfixRef = ref()
 const routeTrafficThroughVpn = ref(false)
 const pushCustomNetworkRoutes = ref<string[]>([])
 const clientToClientNetworkTraffic = ref(false)
@@ -246,6 +251,8 @@ function resetForm() {
   publicIpOrHostname.value = serverData?.ns_public_ip ?? []
   protocol.value = serverData?.proto ?? 'udp'
   port.value = serverData?.port ?? ''
+  tunMtu.value = serverData?.tun_mtu ?? ''
+  mssfix.value = serverData?.mssfix ?? ''
   pushCustomNetworkRoutes.value = serverData?.ns_local ?? []
   compression.value = serverData?.compress ?? 'disabled'
   cipher.value = serverData?.cipher ?? 'auto'
@@ -370,6 +377,16 @@ function validate() {
     [[validateRequired(name.value)], 'ns_description', nameRef],
     [[validateRequired(userDatabase.value)], 'ns_user_db', userDatabaseRef],
     [[validateRequired(port.value), validatePort(port.value)], 'port', portRef],
+    [
+      [validateRequired(tunMtu.value), validateStrictlyPositiveInteger(tunMtu.value)],
+      'tun_mtu',
+      tunMtuRef
+    ],
+    [
+      [validateRequired(mssfix.value), validateStrictlyPositiveInteger(mssfix.value)],
+      'mssfix',
+      mssfixRef
+    ],
     ...(mode.value === 'bridged' ? bridgedServerValidators : routedServerValidators)
   ]
 
@@ -434,7 +451,9 @@ async function createOrEditServer() {
         .map((option) => ({
           option: option.key,
           value: option.value
-        }))
+        })),
+      tun_mtu: tunMtu.value,
+      mssfix: mssfix.value
     })
   } catch (err: any) {
     if (err instanceof ValidationError) {
@@ -662,6 +681,18 @@ watch(
           v-model="port"
           :label="t('standalone.openvpn_rw.port')"
           :invalid-message="t(validationErrorBag.getFirstFor('port'))"
+        />
+        <NeTextInput
+          ref="tunMtuRef"
+          v-model="tunMtu"
+          :label="t('standalone.openvpn_rw.tun_mtu')"
+          :invalid-message="t(validationErrorBag.getFirstFor('tun_mtu'))"
+        />
+        <NeTextInput
+          ref="mssfixRef"
+          v-model="mssfix"
+          :label="t('standalone.openvpn_rw.mssfix')"
+          :invalid-message="t(validationErrorBag.getFirstFor('mssfix'))"
         />
         <div>
           <NeFormItemLabel>{{

--- a/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
@@ -16,7 +16,7 @@ import {
   validateRequiredOption,
   validateUciName,
   type validationOutput,
-  validateStrictlyPositiveInteger
+  validateIpv4Mtu
 } from '@/lib/validation'
 import {
   NeCombobox,
@@ -410,8 +410,8 @@ function validate() {
   // shared form fields validation
   const sharedFieldsValidators: [validationOutput[], string][] = [
     [[validateRequired(name.value), validateUciName(name.value, 10)], 'ns_name'],
-    [[validateRequired(tunMtu.value), validateStrictlyPositiveInteger(tunMtu.value)], 'tun_mtu'],
-    [[validateRequired(mssfix.value), validateStrictlyPositiveInteger(mssfix.value)], 'mssfix'],
+    [[validateRequired(tunMtu.value), validateIpv4Mtu(tunMtu.value)], 'tun_mtu'],
+    [[validateRequired(mssfix.value), validateIpv4Mtu(mssfix.value)], 'mssfix'],
     ...(topology.value === 'p2p' ? p2pValidators : [])
   ]
 

--- a/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
+++ b/src/components/standalone/openvpn_tunnel/CreateOrEditTunnelDrawer.vue
@@ -15,7 +15,8 @@ import {
   validateRequired,
   validateRequiredOption,
   validateUciName,
-  type validationOutput
+  type validationOutput,
+  validateStrictlyPositiveInteger
 } from '@/lib/validation'
 import {
   NeCombobox,
@@ -45,6 +46,8 @@ type TunnelDefaults = {
   ifconfig_remote: string
   route: string[]
   remote: string[]
+  tun_mtu: string
+  mssfix: string
 }
 
 type SharedTunnelPayload = {
@@ -60,6 +63,8 @@ type SharedTunnelPayload = {
   compress?: string
   cipher?: string
   auth?: string
+  tun_mtu: string
+  mssfix: string
 }
 
 type ClientTunnelPayload = {
@@ -117,6 +122,8 @@ const protocol = ref<'tcp' | 'udp'>('udp')
 const compression = ref('disabled')
 const digest = ref('SHA256')
 const cipher = ref('AES-256-GCM')
+const tunMtu = ref('')
+const mssfix = ref('')
 
 // Server tunnel form fields
 const publicEndpoints = ref<string[]>([''])
@@ -281,6 +288,8 @@ async function resetForm() {
     name.value = tunnelData.ns_name
     enabled.value = tunnelData.enabled === '1'
     port.value = tunnelData.port
+    tunMtu.value = tunnelData.tun_mtu
+    mssfix.value = tunnelData.mssfix
     protocol.value = tunnelData.proto
     localP2pIp.value = tunnelData.ifconfig_local ?? ''
     remoteP2pIp.value = tunnelData.ifconfig_remote ?? ''
@@ -337,6 +346,8 @@ async function resetForm() {
         .data as TunnelDefaults
 
       port.value = defaultsPayload.port.toString()
+      tunMtu.value = defaultsPayload.tun_mtu
+      mssfix.value = defaultsPayload.mssfix
       localP2pIp.value = defaultsPayload.ifconfig_local
       remoteP2pIp.value = defaultsPayload.ifconfig_remote
       presharedKey.value = defaultsPayload.secret
@@ -399,6 +410,8 @@ function validate() {
   // shared form fields validation
   const sharedFieldsValidators: [validationOutput[], string][] = [
     [[validateRequired(name.value), validateUciName(name.value, 10)], 'ns_name'],
+    [[validateRequired(tunMtu.value), validateStrictlyPositiveInteger(tunMtu.value)], 'tun_mtu'],
+    [[validateRequired(mssfix.value), validateStrictlyPositiveInteger(mssfix.value)], 'mssfix'],
     ...(topology.value === 'p2p' ? p2pValidators : [])
   ]
 
@@ -516,6 +529,8 @@ async function createOrEditTunnel() {
         ...(isEditing ? { id: id.value } : {}),
         ns_name: name.value,
         port: port.value,
+        tun_mtu: tunMtu.value,
+        mssfix: mssfix.value,
         proto: protocol.value,
         compress: compression.value === 'disabled' ? '' : compression.value,
         enabled: enabled.value ? '1' : '0',
@@ -862,6 +877,18 @@ watch(
           v-model="protocol"
           :label="t('standalone.openvpn_tunnel.protocol')"
           :options="protocolOptions"
+        />
+        <NeTextInput
+          ref="tunMtuRef"
+          v-model="tunMtu"
+          :label="t('standalone.openvpn_tunnel.tun_mtu')"
+          :invalid-message="t(validationErrorBag.getFirstFor('tun_mtu'))"
+        />
+        <NeTextInput
+          ref="mssfixRef"
+          v-model="mssfix"
+          :label="t('standalone.openvpn_tunnel.mssfix')"
+          :invalid-message="t(validationErrorBag.getFirstFor('mssfix'))"
         />
         <NeCombobox
           v-model="compression"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -172,6 +172,7 @@
     "cannot_unregister_hotspot": "Cannot unregister",
     "cannot_load_hotspot_configuration": "Cannot load hotspot configuration",
     "invalid_negative_integer": "Enter an integer number greater than or equal to 0",
+    "invalid_positive_integer": "Enter an integer number greater than 0",
     "empty_network_device": "No network device found",
     "empty_network_device_description": "There must be at least an unassigned device or a device with role 'hotspot'",
     "password_too_short": "Password is too short",
@@ -2039,7 +2040,9 @@
       "type_server_name": "Type the server name '{server}' to confirm",
       "regenerate": "Regenerate",
       "server": "Server",
-      "ca": "CA"
+      "ca": "CA",
+      "tun_mtu": "MTU",
+      "mssfix": "MSSFix"
     },
     "openvpn_tunnel": {
       "title": "OpenVPN tunnel",
@@ -2136,7 +2139,9 @@
       "real_address": "Real address",
       "since": "Connection start",
       "virtual_address": "Virtual address",
-      "remote_host": "Remote hosts"
+      "remote_host": "Remote hosts",
+      "tun_mtu": "MTU",
+      "mssfix": "MSSFix"
     },
     "ipsec_tunnel": {
       "title": "IPsec tunnel",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -172,7 +172,6 @@
     "cannot_unregister_hotspot": "Cannot unregister",
     "cannot_load_hotspot_configuration": "Cannot load hotspot configuration",
     "invalid_negative_integer": "Enter an integer number greater than or equal to 0",
-    "invalid_positive_integer": "Enter an integer number greater than 0",
     "empty_network_device": "No network device found",
     "empty_network_device_description": "There must be at least an unassigned device or a device with role 'hotspot'",
     "password_too_short": "Password is too short",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -190,7 +190,6 @@
     "cannot_retrieve_netdata_configuration": "Impossibile recuperare la configurazione Netdata",
     "cannot_retrieve_tunnel_options": "Impossibile recuperare le opzioni del tunnel",
     "invalid_negative_integer": "Inserire un numero intero maggiore o uguale a 0",
-    "invalid_positive_integer": "Inserire un numero intero maggiore di 0",
     "cannot_cancel_update_schedule": "Impossibile annullare la programmazione dell'aggiornamento",
     "cannot_retrieve_tunnel_defaults": "Impossibile recuperare i valori di default del tunnel",
     "cannot_retrieve_system_board": "Impossibile recuperare la system board",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -190,6 +190,7 @@
     "cannot_retrieve_netdata_configuration": "Impossibile recuperare la configurazione Netdata",
     "cannot_retrieve_tunnel_options": "Impossibile recuperare le opzioni del tunnel",
     "invalid_negative_integer": "Inserire un numero intero maggiore o uguale a 0",
+    "invalid_positive_integer": "Inserire un numero intero maggiore di 0",
     "cannot_cancel_update_schedule": "Impossibile annullare la programmazione dell'aggiornamento",
     "cannot_retrieve_tunnel_defaults": "Impossibile recuperare i valori di default del tunnel",
     "cannot_retrieve_system_board": "Impossibile recuperare la system board",
@@ -1513,7 +1514,9 @@
       "real_address": "Indirizzo reale",
       "since": "Inizio connessione",
       "virtual_address": "Indirizzo virtuale",
-      "remote_host": "Host remoti"
+      "remote_host": "Host remoti",
+      "tun_mtu": "MTU",
+      "mssfix": "MSSFix"
     },
     "ipsec_tunnel": {
       "local_identifier_tooltip": "Inserire una stringa che identifica la macchina corrente; questa stringa dovrebbe iniziare con il carattere '{'@'}. Sull'altra estremità del tunnel, gli identificatori dovrebbero essere invertiti",
@@ -1902,7 +1905,9 @@
       "type_server_name": "Digita il nome del server '{server}' per confermare",
       "regenerate": "Rigenera",
       "server": "Server",
-      "ca": "CA"
+      "ca": "CA",
+      "tun_mtu": "MTU",
+      "mssfix": "MSSFix"
     },
     "qos": {
       "interface": "Interfaccia",

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -599,6 +599,17 @@ export const validatePositiveInteger = (value: string): validationOutput => {
   return { valid: true }
 }
 
+export const validateStrictlyPositiveInteger = (value: string): validationOutput => {
+  if (/\D/.test(value)) {
+    return { valid: false, errMessage: 'error.invalid_positive_integer' }
+  }
+  const intValue = Number.parseInt(value)
+  if (intValue <= 0) {
+    return { valid: false, errMessage: 'error.invalid_positive_integer' }
+  }
+  return { valid: true }
+}
+
 export const validateFutureDate = (value: Date): validationOutput => {
   if (value.getTime() < new Date().getTime()) {
     return { valid: false, errMessage: 'error.invalid_future_date' }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -599,17 +599,6 @@ export const validatePositiveInteger = (value: string): validationOutput => {
   return { valid: true }
 }
 
-export const validateStrictlyPositiveInteger = (value: string): validationOutput => {
-  if (/\D/.test(value)) {
-    return { valid: false, errMessage: 'error.invalid_positive_integer' }
-  }
-  const intValue = Number.parseInt(value)
-  if (intValue <= 0) {
-    return { valid: false, errMessage: 'error.invalid_positive_integer' }
-  }
-  return { valid: true }
-}
-
 export const validateFutureDate = (value: Date): validationOutput => {
   if (value.getTime() < new Date().getTime()) {
     return { valid: false, errMessage: 'error.invalid_future_date' }

--- a/src/views/standalone/vpn/OpenvpnRoadWarriorView.vue
+++ b/src/views/standalone/vpn/OpenvpnRoadWarriorView.vue
@@ -63,6 +63,8 @@ export type RWServer = {
     CA?: number
     server?: number
   }
+  tun_mtu: string
+  mssfix: string
 }
 
 export type RWAccount = {


### PR DESCRIPTION
This pull request adds support for configuring the `tun_mtu` (MTU) and `mssfix` (MSSFix) parameters in both the OpenVPN Road Warrior server and OpenVPN tunnel creation/edit forms. It introduces new form fields, validation, and data handling for these parameters, as well as updates to the English and Italian translations to include labels for these new fields.

**OpenVPN Road Warrior and Tunnel Forms:**

* Added `tun_mtu` and `mssfix` fields to the create/edit forms, including their state management, input fields, and validation using the new `validateIpv4Mtu` function.
* Updated form reset logic to populate `tun_mtu` and `mssfix` from existing server/tunnel data or defaults. 
* Ensured that `tun_mtu` and `mssfix` are included in the payload when creating or editing servers/tunnels.

**Type and Validation Updates:**

* Extended relevant TypeScript types to include `tun_mtu` and `mssfix` fields, and imported the new validation function where needed.

Closes: https://github.com/NethServer/nethsecurity/issues/1192