### PR TITLE
feat(firewall-logging): unify traffic logging option visualization

### DIFF
--- a/src/components/standalone/firewall/PortForwardTable.vue
+++ b/src/components/standalone/firewall/PortForwardTable.vue
@@ -15,14 +15,17 @@ import {
   NeTableBody,
   NeTableRow,
   NeTableCell,
-  NeButton
+  NeButton,
+  NeTooltip
 } from '@nethesis/vue-components'
 import ObjectTooltip from '@/components/standalone/users_objects/ObjectTooltip.vue'
 import {
   faCircleCheck,
   faCircleXmark,
   faClone,
+  faList,
   faPenToSquare,
+  faThumbTack,
   faTrash
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
@@ -124,7 +127,45 @@ function getCellClasses(item: PortForward) {
       <NeTableBody>
         <NeTableRow v-for="item in portForwards" :key="item.id">
           <NeTableCell :data-label="t('standalone.port_forward.name')">
-            <p :class="[...getCellClasses(item)]">{{ item.name }}</p>
+            <div class="flex w-full items-center justify-between gap-2">
+              <div class="flex-1">
+                <p :class="[...getCellClasses(item)]">{{ item.name }}</p>
+              </div>
+              <div class="flex flex-wrap items-center justify-end gap-4">
+                <!-- logging info -->
+                <NeTooltip trigger-event="mouseenter focus" v-if="item.enabled && item.log">
+                  <template #trigger>
+                    <NeLink>
+                      <FontAwesomeIcon
+                        :icon="faList"
+                        class="h-4 w-4 text-indigo-800 dark:text-indigo-300"
+                      />
+                    </NeLink>
+                  </template>
+                  <template #content>
+                    <span> {{ t('standalone.port_forward.logging_enabled') }} </span>
+                  </template>
+                </NeTooltip>
+                <!-- hairpin NAT -->
+                <NeTooltip trigger-event="mouseenter focus" v-if="item.enabled && item.reflection">
+                  <template #trigger>
+                    <NeLink>
+                      <FontAwesomeIcon
+                        :icon="faThumbTack"
+                        class="h-4 w-4 text-indigo-800 dark:text-indigo-300"
+                      />
+                    </NeLink>
+                  </template>
+                  <template #content>
+                    <span>{{
+                      t('standalone.port_forward.hairpin_nat_enabled', {
+                        zones: item.reflection_zone?.map((z: string) => z.toUpperCase()).join(', ')
+                      })
+                    }}</span>
+                  </template>
+                </NeTooltip>
+              </div>
+            </div>
           </NeTableCell>
           <NeTableCell :data-label="t('standalone.port_forward.source_port')">
             <p :class="[...getCellClasses(item)]">

--- a/src/components/standalone/firewall/rules/FirewallRulesContent.vue
+++ b/src/components/standalone/firewall/rules/FirewallRulesContent.vue
@@ -282,7 +282,7 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
       </div>
       <NeButton
         v-if="loading.listRules || rules.length"
-        kind="secondary"
+        kind="primary"
         size="lg"
         class="ml-6 shrink-0"
         @click="showCreateRuleDrawer"

--- a/src/components/standalone/firewall/rules/FirewallRulesTable.vue
+++ b/src/components/standalone/firewall/rules/FirewallRulesTable.vue
@@ -17,6 +17,8 @@ import {
   faCircleXmark,
   faCopy,
   faGripVertical,
+  faList,
+  faTag,
   faTrash
 } from '@fortawesome/free-solid-svg-icons'
 import { useHostSets } from '@/composables/useHostSets'
@@ -354,9 +356,9 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                 <!-- name -->
                 <td :class="!isEnabled(rule) ? disabledRuleClasses : ''">
                   <div
-                    class="flex items-center justify-between gap-2 border-r border-gray-200 pr-4 dark:border-gray-600"
+                    class="flex w-full items-center justify-between gap-2 border-r border-gray-200 pr-4 dark:border-gray-600"
                   >
-                    <div>
+                    <div class="flex-1">
                       <div :class="{ 'opacity-50': !isEnabled(rule) }">
                         {{ rule.name }}
                       </div>
@@ -393,24 +395,39 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                         </NeTooltip>
                       </div>
                     </div>
-                    <!-- show details icon -->
-                    <NeTooltip>
-                      <template #trigger>
-                        <NeLink>
-                          <FontAwesomeIcon :icon="['fas', 'magnifying-glass-plus']" />
-                        </NeLink>
-                      </template>
-                      <template #content>
-                        <div>
-                          <span> {{ t('standalone.firewall_rules.tags') }}: </span>
-                          <span>{{ rule.ns_tag?.join(', ') || '-' }}</span>
-                        </div>
-                        <div>
-                          <span> {{ t('standalone.firewall_rules.logging') }}: </span>
-                          <span>{{ rule.log ? t('common.enabled') : t('common.disabled') }}</span>
-                        </div>
-                      </template>
-                    </NeTooltip>
+                    <div class="flex flex-wrap items-center justify-end gap-4">
+                      <!-- logging info -->
+                      <NeTooltip
+                        trigger-event="mouseenter focus"
+                        v-if="isEnabled(rule) && rule.log"
+                      >
+                        <template #trigger>
+                          <NeLink>
+                            <FontAwesomeIcon
+                              :icon="faList"
+                              class="h-4 w-4 text-indigo-800 dark:text-indigo-300"
+                            />
+                          </NeLink>
+                        </template>
+                        <template #content>
+                          <span> {{ t('standalone.firewall_rules.logging_enabled') }} </span>
+                        </template>
+                      </NeTooltip>
+                      <!-- tags -->
+                      <NeTooltip trigger-event="mouseenter focus" v-if="rule.ns_tag.length > 0">
+                        <template #trigger>
+                          <NeLink>
+                            <FontAwesomeIcon
+                              :icon="faTag"
+                              class="h-4 w-4 text-indigo-800 dark:text-indigo-300"
+                            />
+                          </NeLink>
+                        </template>
+                        <template #content>
+                          <span>{{ rule.ns_tag?.join(', ') }}</span>
+                        </template>
+                      </NeTooltip>
+                    </div>
                   </div>
                 </td>
                 <!-- source -->

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1505,7 +1505,8 @@
       "zone_dmz_color": "Orange",
       "preset_active_title": "Preset selected",
       "preset_active_description": "When you create this zone, the system will automatically add firewall rules to allow access to essential services. You can view or modify them anytime under Firewall > Rules > Input Rules.",
-      "choose_one_or_more_zones": "Choose one or more zones"
+      "choose_one_or_more_zones": "Choose one or more zones",
+      "logging_enabled": "Logging enabled"
     },
     "port_forward": {
       "title": "Port forward",
@@ -1537,6 +1538,8 @@
       "log": "Log",
       "hairpin_nat": "Hairpin NAT",
       "hairpin_nat_zones": "Hairpin NAT enabled on following zones",
+      "hairpin_nat_enabled": "Hairpin NAT enabled on {zones}",
+      "logging_enabled": "Logging enabled",
       "choose_zone": "Choose zone",
       "choose_protocol": "Choose protocol",
       "protocol_helper": "Leave unselected for any source protocol",
@@ -1642,7 +1645,8 @@
       "destination_object": "Destination object",
       "inactive": "Inactive",
       "zone_no_longer_exists": "This rule is inactive because it uses a zone that no longer exists",
-      "disabled_rule": "This rule has been manually disabled, but can be re-enabled"
+      "disabled_rule": "This rule has been manually disabled, but can be re-enabled",
+      "logging_enabled": "Logging enabled"
     },
     "firewall": {
       "title": "Firewall"

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1051,7 +1051,8 @@
       "zone_dmz_color": "Orange",
       "preset_active_title": "Preset selezionato",
       "preset_active_description": "Quando si crea questa zona, il sistema aggiungerà automaticamente le regole firewall per consentire l'accesso ai servizi essenziali. È possibile visualizzarli o modificarli in qualsiasi momento sotto Firewall > Regole > Regole di input.",
-      "choose_one_or_more_zones": "Scegliere una o più zone"
+      "choose_one_or_more_zones": "Scegliere una o più zone",
+      "logging_enabled": "Logging abilitato"
     },
     "port_forward": {
       "disable": "Disabilita",
@@ -1078,6 +1079,8 @@
       "status": "Stato",
       "title": "Port forward",
       "hairpin_nat_zones": "Hairpin NAT abilitato sulle seguenti zone",
+      "hairpin_nat_enabled": "Hairpin NAT abilitato su {zones}",
+      "logging_enabled": "Logging abilitato",
       "log": "Log",
       "wan_ip": "IP WAN",
       "destination_port": "Porta di destinazione",
@@ -1996,7 +1999,8 @@
       "destination_object": "Oggetto di destinazione",
       "inactive": "Inattiva",
       "zone_no_longer_exists": "Questa regola è stata disattivata perché utilizza una zona che non esiste più",
-      "disabled_rule": "Questa regola è stata disabilitata manualmente, ma può essere riattivata"
+      "disabled_rule": "Questa regola è stata disabilitata manualmente, ma può essere riattivata",
+      "logging_enabled": "Logging abilitato"
     },
     "certificates": {
       "title": "Certificati",

--- a/src/views/standalone/firewall/ZonesAndPolicies.vue
+++ b/src/views/standalone/firewall/ZonesAndPolicies.vue
@@ -18,7 +18,8 @@ import {
   NeTableCell,
   NePaginator,
   NeEmptyState,
-  useItemPagination
+  useItemPagination,
+  NeTooltip
 } from '@nethesis/vue-components'
 import { useI18n } from 'vue-i18n'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
@@ -33,7 +34,13 @@ import {
   getZoneColorClasses,
   getIconFromZone
 } from '@/lib/standalone/network'
-import { faPenToSquare, faTrash } from '@fortawesome/free-solid-svg-icons'
+import {
+  faArrowRight,
+  faBan,
+  faList,
+  faPenToSquare,
+  faTrash
+} from '@fortawesome/free-solid-svg-icons'
 
 const { t } = useI18n()
 const firewallConfig = useFirewallStore()
@@ -89,7 +96,7 @@ function editZone(zone: Zone) {
       </p>
       <div>
         <!-- TODO: add settings -->
-        <NeButton kind="secondary" size="lg" @click="createZone">
+        <NeButton kind="primary" size="lg" @click="createZone">
           <template #prefix>
             <FontAwesomeIcon :icon="['fas', 'circle-plus']" />
           </template>
@@ -123,7 +130,6 @@ function editZone(zone: Zone) {
           t('standalone.zones_and_policies.traffic_to_same_zone')
         }}</NeTableHeadCell>
         <NeTableHeadCell>{{ t('standalone.zones_and_policies.interfaces') }}</NeTableHeadCell>
-        <NeTableHeadCell>{{ t('standalone.zones_and_policies.logging') }}</NeTableHeadCell>
         <NeTableHeadCell>
           <!-- no header for actions -->
         </NeTableHeadCell>
@@ -140,14 +146,33 @@ function editZone(zone: Zone) {
         </NeTableRow>
         <NeTableRow v-for="item in paginatedItems" v-else :key="item.name">
           <NeTableCell :data-label="t('standalone.zones_and_policies.zone')">
-            <div class="flex items-center gap-x-4">
-              <div
-                :class="getZoneColorClasses(item.name)"
-                class="flex h-10 w-10 items-center justify-center rounded-full"
-              >
-                <FontAwesomeIcon :icon="getIconFromZone(item.name)" class="h-5 w-5" />
+            <div class="flex w-full items-center justify-between gap-2">
+              <div>
+                <div class="flex items-center gap-x-4">
+                  <div
+                    :class="getZoneColorClasses(item.name)"
+                    class="flex h-10 w-10 items-center justify-center rounded-full"
+                  >
+                    <FontAwesomeIcon :icon="getIconFromZone(item.name)" class="h-5 w-5" />
+                  </div>
+                  <span class="uppercase">{{ item.name }}</span>
+                </div>
               </div>
-              <span class="uppercase">{{ item.name }}</span>
+              <div>
+                <NeTooltip trigger-event="mouseenter focus" v-if="item.logging">
+                  <template #trigger>
+                    <NeLink>
+                      <FontAwesomeIcon
+                        :icon="faList"
+                        class="h-4 w-4 text-indigo-800 dark:text-indigo-300"
+                      />
+                    </NeLink>
+                  </template>
+                  <template #content>
+                    <span> {{ t('standalone.zones_and_policies.logging_enabled') }} </span>
+                  </template>
+                </NeTooltip>
+              </div>
             </div>
           </NeTableCell>
           <NeTableCell :data-label="t('standalone.zones_and_policies.allow_forwards_to')">
@@ -171,24 +196,38 @@ function editZone(zone: Zone) {
                 -</template
               >
               <template v-else-if="getTrafficToWan(item, firewallConfig.forwardings)">
-                <FontAwesomeIcon :icon="['fas', 'arrow-right']" />
+                <FontAwesomeIcon :icon="faArrowRight" class="text-green-700 dark:text-green-500" />
                 <p>ACCEPT</p>
               </template>
               <template v-else>
-                <FontAwesomeIcon :icon="['fas', 'ban']" />
+                <FontAwesomeIcon :icon="faBan" class="text-rose-700 dark:text-rose-500" />
                 <p>REJECT</p>
               </template>
             </div>
           </NeTableCell>
           <NeTableCell :data-label="t('standalone.zones_and_policies.traffic_to_firewall')">
             <div class="flex items-center gap-x-2">
-              <FontAwesomeIcon :icon="['fas', trafficIcon(item.input)]" />
+              <FontAwesomeIcon
+                :icon="['fas', trafficIcon(item.input)]"
+                :class="[
+                  item.input === TrafficPolicy.ACCEPT
+                    ? 'text-green-700 dark:text-green-500'
+                    : 'text-rose-700 dark:text-rose-500'
+                ]"
+              />
               {{ item.input.toUpperCase() }}
             </div>
           </NeTableCell>
           <NeTableCell :data-label="t('standalone.zones_and_policies.traffic_to_same_zone')">
             <div class="flex items-center gap-x-2">
-              <FontAwesomeIcon :icon="['fas', trafficIcon(item.forward)]" />
+              <FontAwesomeIcon
+                :icon="['fas', trafficIcon(item.forward)]"
+                :class="[
+                  item.forward === TrafficPolicy.ACCEPT
+                    ? 'text-green-700 dark:text-green-500'
+                    : 'text-rose-700 dark:text-rose-500'
+                ]"
+              />
               {{ item.forward.toUpperCase() }}
             </div>
           </NeTableCell>
@@ -197,16 +236,6 @@ function editZone(zone: Zone) {
               {{ item.interfaces.join(', ') }}
             </template>
             <template v-else>-</template>
-          </NeTableCell>
-          <NeTableCell :data-label="t('standalone.zones_and_policies.logging')">
-            <div class="flex items-center gap-2">
-              <font-awesome-icon
-                :icon="['fas', item.logging ? 'circle-check' : 'circle-xmark']"
-                :class="['h-4 w-4', { 'text-green-600 dark:text-green-400': item.logging }]"
-                aria-hidden="true"
-              />
-              {{ item.logging ? t('common.enabled') : t('common.disabled') }}
-            </div>
           </NeTableCell>
           <NeTableCell :data-label="t('common.actions')">
             <div class="-ml-2.5 flex 2xl:ml-0">


### PR DESCRIPTION
This pull request introduces several UI enhancements to the firewall management views, focusing on improving the visibility and clarity of logging and tagging information for zones, port forwards, and firewall rules. The changes add icon-based tooltips to indicate logging and tagging status, update button styles for consistency, and improve the use of color to communicate policy states. Additionally, translation files are updated to support the new tooltips and labels.

**UI/UX Improvements:**

* Added icon-based tooltips to display logging status for zones in `ZonesAndPolicies.vue`, port forwards in `PortForwardTable.vue`, and firewall rules in `FirewallRulesTable.vue`, replacing or supplementing previous text-based indicators.
* Introduced a tooltip with a tag icon to display firewall rule tags in `FirewallRulesTable.vue`.
* Updated button styles from "secondary" to "primary" for create actions in both `ZonesAndPolicies.vue` and `FirewallRulesContent.vue` for better visual prominence.
* Improved color coding for action icons (accept/reject) and traffic policy indicators in `ZonesAndPolicies.vue` to enhance clarity and accessibility.

Closes: https://github.com/NethServer/nethsecurity/issues/1456