### PR TITLE
fix(firewall-section): update tooltips visibility and styles

### DIFF
--- a/src/components/standalone/firewall/PortForwardTable.vue
+++ b/src/components/standalone/firewall/PortForwardTable.vue
@@ -133,12 +133,18 @@ function getCellClasses(item: PortForward) {
               </div>
               <div class="flex flex-wrap items-center justify-end gap-4">
                 <!-- logging info -->
-                <NeTooltip v-if="item.enabled && item.log" trigger-event="mouseenter focus">
+                <NeTooltip v-if="item.log" trigger-event="mouseenter focus">
                   <template #trigger>
                     <NeLink>
                       <FontAwesomeIcon
                         :icon="faList"
-                        class="h-4 w-4 text-indigo-800 dark:text-indigo-300"
+                        :class="[
+                          'h-4',
+                          'w-4',
+                          item.enabled
+                            ? 'text-indigo-800 dark:text-indigo-300'
+                            : getCellClasses(item)
+                        ]"
                       />
                     </NeLink>
                   </template>
@@ -147,12 +153,18 @@ function getCellClasses(item: PortForward) {
                   </template>
                 </NeTooltip>
                 <!-- hairpin NAT -->
-                <NeTooltip v-if="item.enabled && item.reflection" trigger-event="mouseenter focus">
+                <NeTooltip v-if="item.reflection" trigger-event="mouseenter focus">
                   <template #trigger>
                     <NeLink>
                       <FontAwesomeIcon
                         :icon="faThumbTack"
-                        class="h-4 w-4 text-indigo-800 dark:text-indigo-300"
+                        :class="[
+                          'h-4',
+                          'w-4',
+                          item.enabled
+                            ? 'text-indigo-800 dark:text-indigo-300'
+                            : getCellClasses(item)
+                        ]"
                       />
                     </NeLink>
                   </template>

--- a/src/components/standalone/firewall/rules/CreateOrEditFirewallRuleDrawer.vue
+++ b/src/components/standalone/firewall/rules/CreateOrEditFirewallRuleDrawer.vue
@@ -590,7 +590,9 @@ function validate() {
       isValidationOk = false
       focusElement(sourceZoneRef)
     } else if (action.value === 'NOTRACK' && sourceZone.value === '*') {
-      errorBag.value.set('src', [t('standalone.firewall_rules.notrack_requires_specific_source_zone')])
+      errorBag.value.set('src', [
+        t('standalone.firewall_rules.notrack_requires_specific_source_zone')
+      ])
       isValidationOk = false
       focusElement(sourceZoneRef)
     }

--- a/src/components/standalone/firewall/rules/FirewallRulesTable.vue
+++ b/src/components/standalone/firewall/rules/FirewallRulesTable.vue
@@ -401,15 +401,18 @@ function searchStringInRule(rule: FirewallRule, queryText: string) {
                     </div>
                     <div class="flex flex-wrap items-center justify-end gap-4">
                       <!-- logging info -->
-                      <NeTooltip
-                        v-if="isEnabled(rule) && rule.log"
-                        trigger-event="mouseenter focus"
-                      >
+                      <NeTooltip v-if="rule.log" trigger-event="mouseenter focus">
                         <template #trigger>
                           <NeLink>
                             <FontAwesomeIcon
                               :icon="faList"
-                              class="h-4 w-4 text-indigo-800 dark:text-indigo-300"
+                              :class="[
+                                'h-4',
+                                'w-4',
+                                isEnabled(rule)
+                                  ? 'text-indigo-800 dark:text-indigo-300'
+                                  : 'text-gray-500 opacity-50 dark:text-gray-400'
+                              ]"
                             />
                           </NeLink>
                         </template>


### PR DESCRIPTION
Based on the [latest comment](https://github.com/NethServer/nethsecurity/issues/1456#issuecomment-4554713341) on the issue, this PR includes the following modifications:

- the logging tooltip is now shown in the port forwarding and rules sections even if the rule is disabled (displayed in gray and with opacity)
- the hairpin NAT tooltip is now shown in the port forwarding section even if the rule is disabled (displayed in gray and with opacity).

Closes: https://github.com/NethServer/nethsecurity/issues/1456