### PR TITLE
fix(monitoring): using correct label for netifyd analyzed traffic

### DIFF
--- a/src/components/standalone/monitoring/TrafficMonitor.vue
+++ b/src/components/standalone/monitoring/TrafficMonitor.vue
@@ -157,7 +157,7 @@ const hoursDatasets = computed(() => {
               <p class="text-lg">{{ get('host') }}</p>
             </SimpleStat>
           </NeCard>
-          <NeCard :title="t('standalone.real_time_monitor.daily_total_traffic')">
+          <NeCard :title="t('standalone.real_time_monitor.traffic_analyzed_today')">
             <SimpleStat>
               <span v-if="data.total_traffic != 0">{{ byteFormat1024(data.total_traffic) }}</span>
               <span v-else> - </span>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2343,7 +2343,7 @@
       "no_applications": "No applications",
       "today_top_protocols": "Protocols",
       "no_protocols": "No protocols",
-      "daily_total_traffic": "Daily total traffic",
+      "traffic_analyzed_today": "Traffic analyzed today",
       "top_talkers": "Top Talkers",
       "today_traffic": "Today traffic",
       "recent_traffic": "Recent traffic",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -2444,7 +2444,7 @@
       "description": "Analisi approfondita delle prestazioni del sistema e delle applicazioni, metriche dettagliate e visualizzazioni. I dati di monitoraggio vengono memorizzati in RAM e ripristinati al riavvio dell'unità. Se l'unità è collegata a un controller remoto, le metriche vengono salvate anche sul controller e persistono al riavvio dell'unità .",
       "times_blocked": "Numero blocchi",
       "timestamp": "Data e ora",
-      "daily_total_traffic": "Traffico totale giornaliero",
+      "traffic_analyzed_today": "Traffico analizzato oggi",
       "public_ip_address": "Indirizzo IP pubblico",
       "latency_and_packet_delivery_rate": "Latenza e delivery rate pacchetti",
       "error_fetching_data": "Errore nel recupero dei dati",


### PR DESCRIPTION
Updated needed by https://github.com/NethServer/nethsecurity/pull/1700 since now netifyd will not analyze ALL traffic.

Before:
<img width="915" height="808" alt="image" src="https://github.com/user-attachments/assets/45757cc4-c5b5-4966-93ff-83006cf20fcd" />

After:
<img width="915" height="808" alt="image" src="https://github.com/user-attachments/assets/6df63ce0-0ddc-4b43-a7b7-05f30222d5d0" />
