### PR TITLE
fix: disable alert pooling during updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@commitlint/config-conventional": "^21.0.0",
         "@rushstack/eslint-patch": "^1.2.0",
         "@tailwindcss/forms": "^0.5.9",
-        "@tanstack/vue-query-devtools": "^6.1.5",
+        "@tanstack/vue-query-devtools": "^6.1.34",
         "@tsconfig/node24": "^24.0.0",
         "@types/jsdom": "^28.0.1",
         "@types/node": "^22",
@@ -3091,9 +3091,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.100.14",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
-      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3101,9 +3101,9 @@
       }
     },
     "node_modules/@tanstack/query-devtools": {
-      "version": "5.100.14",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.14.tgz",
-      "integrity": "sha512-g96SmSSQecYTYcyuAMRXr895GplJv01UGt7qttQWPOUyZ5EGz5tbRc589bMc2m5BsPFD6O0PCEAHdbDYNP6UBw==",
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.101.0.tgz",
+      "integrity": "sha512-MVqw17k08RQtGGLEL654+dX/btbX9p/8WjkznO//zusLTMaObxi3Q+MoFwGVkC9K3tqjn8qrrNhJevXx4fJTeQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3122,13 +3122,13 @@
       }
     },
     "node_modules/@tanstack/vue-query": {
-      "version": "5.100.14",
-      "resolved": "https://registry.npmjs.org/@tanstack/vue-query/-/vue-query-5.100.14.tgz",
-      "integrity": "sha512-gNKay40Z29mvnjJtq2emzbZhGd2HRZQTOJuJZxAWpUKnmjOf79BndNnF1Aowm0Nt4WQtXYjFCGNZkBzSEJ+JEg==",
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-query/-/vue-query-5.101.0.tgz",
+      "integrity": "sha512-sZeW0RvfEZ9QRiaXirE/HQZsFT5saMlPZVfeYvjPX6lqSBS9lkD7wfnCfzOBns6HD2f34Gx9cazkuU3Xj6hl/A==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/match-sorter-utils": "^8.19.4",
-        "@tanstack/query-core": "5.100.14",
+        "@tanstack/query-core": "5.101.0",
         "@vue/devtools-api": "^6.6.3",
         "vue-demi": "^0.14.10"
       },
@@ -3147,20 +3147,20 @@
       }
     },
     "node_modules/@tanstack/vue-query-devtools": {
-      "version": "6.1.33",
-      "resolved": "https://registry.npmjs.org/@tanstack/vue-query-devtools/-/vue-query-devtools-6.1.33.tgz",
-      "integrity": "sha512-ZjWN+UNeBgM4yf+PSpf/HVQA/hP/GOlOGLt9iy/zFK9pxguUVy69YG2ibe5kJmcHUlArsFSOHVqlUu2VCWcisA==",
+      "version": "6.1.34",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-query-devtools/-/vue-query-devtools-6.1.34.tgz",
+      "integrity": "sha512-Dhfmnfiodf6RfPa3jw8rpFG3SK6ok+wPeAHSRVth2CTWoGxGDyKmTe02HTyEUmn2mJlxvhseUO8a/fgcUQfX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-devtools": "5.100.14"
+        "@tanstack/query-devtools": "5.101.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/vue-query": "^5.100.14",
+        "@tanstack/vue-query": "^5.101.0",
         "vue": "^3.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@commitlint/config-conventional": "^21.0.0",
     "@rushstack/eslint-patch": "^1.2.0",
     "@tailwindcss/forms": "^0.5.9",
-    "@tanstack/vue-query-devtools": "^6.1.5",
+    "@tanstack/vue-query-devtools": "^6.1.34",
     "@tsconfig/node24": "^24.0.0",
     "@types/jsdom": "^28.0.1",
     "@types/node": "^22",

--- a/src/StandaloneApp.vue
+++ b/src/StandaloneApp.vue
@@ -19,6 +19,7 @@ import { UnauthorizedAction, useSudoStore } from '@/stores/standalone/sudo.ts'
 import AskSudoPasswordModal from '@/components/standalone/AskSudoPasswordModal.vue'
 import WizardShell from './views/standalone/wizard/WizardShell.vue'
 import ToastNotificationsArea from './components/ToastNotificationsArea.vue'
+import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
 
 const loginStore = useLoginStore()
 const unitsStore = useUnitsStore()
@@ -184,4 +185,5 @@ function configureAxios() {
       <StandaloneAppLogin />
     </template>
   </template>
+  <VueQueryDevtools />
 </template>

--- a/src/components/standalone/update/UpdatePackagesModal.vue
+++ b/src/components/standalone/update/UpdatePackagesModal.vue
@@ -11,6 +11,7 @@ import { NeProgressBar, NeInlineNotification, getAxiosErrorMessage } from '@neth
 import { NeModal } from '@nethesis/vue-components'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useSystemActionStore } from '@/stores/standalone/systemAction'
 
 const UPDATE_WAIT_TIME = 20000
 
@@ -26,6 +27,7 @@ const error = ref({
 const emit = defineEmits(['close', 'packages-updated'])
 
 const { t } = useI18n()
+const systemActionStore = useSystemActionStore()
 
 const isSubmittingUpdateRequest = ref(false)
 const isUpdatingPackages = ref(false)
@@ -34,6 +36,8 @@ const { startTimer, currentProgress, clearTimer } = useTimer({
   duration: UPDATE_WAIT_TIME,
   progressStep: 0.5,
   onTimerFinish: () => {
+    // Resume polling queries (e.g. alerts): services are back up
+    systemActionStore.setSystemActionInProgress(false)
     emit('packages-updated')
     clearTimer()
     close()
@@ -52,6 +56,8 @@ async function updatePackages() {
     isSubmittingUpdateRequest.value = true
     await ubusCall('ns.update', 'install-package-updates')
     isUpdatingPackages.value = true
+    // Pause polling queries (e.g. alerts) while services restart during install
+    systemActionStore.setSystemActionInProgress(true)
     startTimer()
   } catch (err: any) {
     error.value.notificationDescription = t(getAxiosErrorMessage(err))

--- a/src/composables/useAlerts.ts
+++ b/src/composables/useAlerts.ts
@@ -38,7 +38,7 @@ export function useAlerts() {
     queryFn: async () =>
       await ubusCall<AxiosResponse<ListAlertsResponse>>('ns.telegraf', 'list-alerts'),
     select: (response) => response.data.alerts,
-    refetchInterval: 5000
+    refetchInterval: 15000
   })
 
   const notifications = computed<NeNotificationV2[]>(() => {

--- a/src/composables/useAlerts.ts
+++ b/src/composables/useAlerts.ts
@@ -4,6 +4,7 @@ import type { AxiosResponse } from 'axios'
 import type { NeNotificationV2 } from '@nethesis/vue-components'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useSystemActionStore } from '@/stores/standalone/systemAction'
 
 export type Alert = {
   id?: string
@@ -32,13 +33,18 @@ function getSeverityBadgeKind(severity: string | undefined): NeNotificationV2['k
 
 export function useAlerts() {
   const { locale, t } = useI18n()
+  const systemActionStore = useSystemActionStore()
 
   const { data, error, status, isPending, isError, dataUpdatedAt } = useQuery({
     queryKey: ['metrics', 'alerts'],
     queryFn: async () =>
       await ubusCall<AxiosResponse<ListAlertsResponse>>('ns.telegraf', 'list-alerts'),
     select: (response) => response.data.alerts,
-    refetchInterval: 15000
+    refetchInterval: 15000,
+    // Pause polling while a disruptive system action (reboot, update, image
+    // flash) is in progress: the device is temporarily unreachable and the UI
+    // reloads once the action completes, re-enabling the query.
+    enabled: computed(() => !systemActionStore.isSystemActionInProgress)
   })
 
   const notifications = computed<NeNotificationV2[]>(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,8 +40,6 @@ app.use(
 )
 
 // tanstack
-app.use(VueQueryPlugin, {
-  enableDevtoolsV6Plugin: true
-})
+app.use(VueQueryPlugin)
 
 app.mount('#app')

--- a/src/stores/standalone/systemAction.ts
+++ b/src/stores/standalone/systemAction.ts
@@ -1,0 +1,25 @@
+//  Copyright (C) 2026 Nethesis S.r.l.
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+/**
+ * Tracks whether a disruptive system action (reboot, system update or image
+ * flash) is currently in progress. While such an action runs, the device
+ * becomes temporarily unreachable, so polling queries (e.g. alerts) should be
+ * paused to avoid spurious errors. The UI reloads once the action completes,
+ * which resets this state.
+ */
+export const useSystemActionStore = defineStore('systemAction', () => {
+  const isSystemActionInProgress = ref(false)
+
+  const setSystemActionInProgress = (inProgress: boolean) => {
+    isSystemActionInProgress.value = inProgress
+  }
+
+  return {
+    isSystemActionInProgress,
+    setSystemActionInProgress
+  }
+})

--- a/src/views/standalone/system/RebootAndShutdownView.vue
+++ b/src/views/standalone/system/RebootAndShutdownView.vue
@@ -18,6 +18,7 @@ import { onMounted, onUnmounted } from 'vue'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useUciPendingChangesStore } from '@/stores/standalone/uciPendingChanges'
+import { useSystemActionStore } from '@/stores/standalone/systemAction'
 import { faArrowsRotate, faPowerOff } from '@fortawesome/free-solid-svg-icons'
 
 type requestType = 'poweroff' | 'reboot'
@@ -27,6 +28,7 @@ const POLL_TIMEOUT = 60000 * 3 // 3 minutes
 
 const { t } = useI18n()
 const uciChangesStore = useUciPendingChangesStore()
+const systemActionStore = useSystemActionStore()
 
 const hostname = ref('')
 const loading = ref(true)
@@ -95,6 +97,8 @@ async function getHostname() {
 async function performRequest(type: requestType) {
   try {
     isPerformingRequest.value = true
+    // Pause polling queries (e.g. alerts) while the device goes offline
+    systemActionStore.setSystemActionInProgress(true)
     await ubusCall('ns.power', type)
 
     if (type == 'reboot') {
@@ -102,6 +106,8 @@ async function performRequest(type: requestType) {
       startPolling()
     }
   } catch (err: any) {
+    // Re-enable polling queries since the action did not start
+    systemActionStore.setSystemActionInProgress(false)
     modalRequestError.value = t(getAxiosErrorMessage(err))
   } finally {
     isPerformingRequest.value = false

--- a/src/views/standalone/system/UpdateView.vue
+++ b/src/views/standalone/system/UpdateView.vue
@@ -18,8 +18,8 @@ import UpdatePackagesModal from '@/components/standalone/update/UpdatePackagesMo
 import SystemUpdateInProgressModal from '@/components/standalone/update/SystemUpdateInProgressModal.vue'
 import { getProductName } from '@/lib/config'
 import { useNotificationsStore } from '@/stores/notifications'
+import { useSystemActionStore } from '@/stores/standalone/systemAction'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-
 export type PackageUpdate = {
   package: string
   currentVersion: string
@@ -34,6 +34,7 @@ export type SystemUpdate = {
 
 const { t } = useI18n()
 const notificationsStore = useNotificationsStore()
+const systemActionStore = useSystemActionStore()
 
 const loading = ref(true)
 const error = ref({
@@ -73,6 +74,12 @@ function cleanError() {
   error.value.notificationTitle = ''
   error.value.notificationDescription = ''
   error.value.notificationDetails = ''
+}
+
+function onSystemUpdateStarted() {
+  isApplyingSystemUpdate.value = true
+  // Pause polling queries (e.g. alerts) while the device reboots/updates
+  systemActionStore.setSystemActionInProgress(true)
 }
 
 async function fetchUpdatesStatus() {
@@ -397,12 +404,12 @@ onMounted(() => {
     :schedule-to-edit="scheduleDate"
     @close="showScheduleUpdateDrawer = false"
     @schedule-saved="fetchUpdatesStatus"
-    @system-update-requested="isApplyingSystemUpdate = true"
+    @system-update-requested="onSystemUpdateStarted"
   />
   <UploadImageDrawer
     :is-shown="showUploadImageDrawer"
     @close="showUploadImageDrawer = false"
-    @update-requested="isApplyingSystemUpdate = true"
+    @update-requested="onSystemUpdateStarted"
   />
   <SystemUpdateInProgressModal :visible="isApplyingSystemUpdate" />
 </template>


### PR DESCRIPTION
When doing something that distrupts the behind-the-scenes of the firewall (reboot or update) UI errors out since there's a continuos pool for alerts behind the scenes.
This addresses the issue, widens the alert pool and installs tanstack devtools.

