### PR TITLE
fix(ovpn-rw): update error message for certificate regeneration failure

### DIFF
--- a/src/components/standalone/openvpn_rw/RegenerateRWAllCertificatesModal.vue
+++ b/src/components/standalone/openvpn_rw/RegenerateRWAllCertificatesModal.vue
@@ -68,7 +68,7 @@ function close() {
     <NeInlineNotification
       v-if="error"
       kind="error"
-      :title="t('error.cannot_renew_server_cert')"
+      :title="t('error.cannot_regenerate_all_certs')"
       :description="t(getAxiosErrorMessage(error))"
       class="mb-2"
     />


### PR DESCRIPTION
This pull request contains a minor fix to the error text shown in the modal notification when the regeneration of all certificates fails in the OpenVPN Road Warrior section.
<img width="451" height="353" alt="image" src="https://github.com/user-attachments/assets/f7aebcea-83f1-496a-b5a4-01c023aaf8aa" />
