### PR TITLE
fix(ui): preserve page size for lease tables

### DIFF
--- a/src/components/standalone/dns_dhcp/DynamicLeases.vue
+++ b/src/components/standalone/dns_dhcp/DynamicLeases.vue
@@ -171,8 +171,8 @@ function clearFilters() {
         {{ error.notificationDetails }}
       </template>
     </NeInlineNotification>
-    <NeSkeleton v-if="loading" :lines="10" />
-    <template v-else>
+    <NeSkeleton v-show="loading" :lines="10" />
+    <div v-show="!loading">
       <NeEmptyState
         v-if="items.length == 0"
         :title="t('standalone.dns_dhcp.no_dynamic_lease_found')"
@@ -190,7 +190,7 @@ function clearFilters() {
         :show-dynamic-leases="true"
         @create-static-lease-from-dynamic="openCreateStaticLeaseDrawer"
       />
-    </template>
+    </div>
   </div>
   <CreateOrEditStaticLeaseDrawer
     :is-shown="showCreateStaticLeaseDrawer"

--- a/src/components/standalone/dns_dhcp/StaticLeases.vue
+++ b/src/components/standalone/dns_dhcp/StaticLeases.vue
@@ -191,8 +191,8 @@ function clearFilters() {
         {{ error.notificationDetails }}
       </template>
     </NeInlineNotification>
-    <NeSkeleton v-if="loading" :lines="10" />
-    <template v-else>
+    <NeSkeleton v-show="loading" :lines="10" />
+    <div v-show="!loading">
       <NeEmptyState
         v-if="items.length == 0"
         :title="t('standalone.dns_dhcp.no_reservation_configured')"
@@ -218,7 +218,7 @@ function clearFilters() {
         @lease-delete="openDeleteModal"
         @lease-edit="openCreateEditDrawer"
       />
-    </template>
+    </div>
   </div>
   <CreateOrEditStaticLeaseDrawer
     :is-shown="showCreateEditDrawer"


### PR DESCRIPTION
Toggling loading via `v-if/v-else` unmounted LeasesTable on every
refetch, resetting its selected page size back to the default.
Switch to `v-show` so the skeleton overlays the table instead of
replacing it.