### PR TITLE
fix(ui): update button styles and labels

### DIFF
--- a/src/components/standalone/NeStepper.vue
+++ b/src/components/standalone/NeStepper.vue
@@ -7,10 +7,16 @@
 import { NeProgressBar } from '@nethesis/vue-components'
 import { range } from 'lodash-es'
 
-defineProps<{
+const {
+  totalSteps,
+  currentStep,
+  stepLabel,
+  labelColorClasses = 'text-primary-600 dark:text-primary-500'
+} = defineProps<{
   totalSteps: number
   currentStep: number
   stepLabel: string
+  labelColorClasses?: string
 }>()
 </script>
 
@@ -19,7 +25,7 @@ defineProps<{
     <NeProgressBar :progress="(currentStep / totalSteps) * 100" size="sm" />
     <div class="mt-2 flex flex-row">
       <div v-for="i in range(1, totalSteps + 1)" :key="i" class="flex grow basis-0 justify-center">
-        <p v-if="i == currentStep" class="text-xs font-semibold text-primary-400">
+        <p v-if="i == currentStep" class="text-xs font-semibold" :class="labelColorClasses">
           {{ stepLabel }} {{ currentStep }}/{{ totalSteps }}
         </p>
       </div>

--- a/src/components/standalone/firewall/nat/NatRulesContent.vue
+++ b/src/components/standalone/firewall/nat/NatRulesContent.vue
@@ -96,7 +96,7 @@ function hideCreateOrEditRuleDrawer() {
       </div>
       <NeButton
         v-if="loading.listRules || natRules.length"
-        kind="secondary"
+        kind="primary"
         size="lg"
         class="shrink-0"
         @click="showCreateRuleDrawer"

--- a/src/components/standalone/security/ips/IpsSuppressedAlerts.vue
+++ b/src/components/standalone/security/ips/IpsSuppressedAlerts.vue
@@ -26,7 +26,7 @@ import {
   useItemPagination,
   useSort
 } from '@nethesis/vue-components'
-import { faCircleInfo, faCirclePlus, faShield, faTrash } from '@fortawesome/free-solid-svg-icons'
+import { faBellSlash, faCircleInfo, faShield, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { ubusCall } from '@/lib/standalone/ubus'
 import type { AxiosResponse } from 'axios'
@@ -147,9 +147,9 @@ function handleDeleted() {
         <NeTextInput v-model.trim="filter" :placeholder="t('common.filter')" is-search />
         <NeButton kind="primary" size="lg" @click="suppressingAlert = true">
           <template #prefix>
-            <FontAwesomeIcon :icon="faCirclePlus" aria-hidden="true" class="h-4 w-4" />
+            <FontAwesomeIcon :icon="faBellSlash" aria-hidden="true" class="h-4 w-4" />
           </template>
-          {{ t('standalone.ips.add_bypass') }}
+          {{ t('standalone.ips.add_suppressed_alert') }}
         </NeButton>
       </div>
       <NeTable
@@ -244,7 +244,7 @@ function handleDeleted() {
     <NeEmptyState v-else :icon="faShield" :title="t('standalone.ips.no_suppressed_alerts')">
       <NeButton kind="primary" size="lg" @click="suppressingAlert = true">
         <template #prefix>
-          <FontAwesomeIcon :icon="faCirclePlus" aria-hidden="true" class="h-4 w-4" />
+          <FontAwesomeIcon :icon="faBellSlash" aria-hidden="true" class="h-4 w-4" />
         </template>
         {{ t('standalone.ips.add_suppressed_alert') }}
       </NeButton>

--- a/src/components/standalone/ssh/SshKeys.vue
+++ b/src/components/standalone/ssh/SshKeys.vue
@@ -167,6 +167,9 @@ function handleCloseDeleteModal() {
     :title="t('standalone.ssh.ssh_keys.title')"
   >
     <div class="space-y-4">
+      <p v-if="sshKeys.length > 0">
+        {{ t('standalone.ssh.ssh_keys.public_keys_label') }}
+      </p>
       <ul class="space-y-2">
         <li v-for="key in sshKeys" :key="key.key" class="flex items-center gap-2">
           <div class="min-w-0 grow rounded border border-gray-200 p-3 text-xs dark:border-gray-700">

--- a/src/components/standalone/wireguard/WireguardPeerTunnelList.vue
+++ b/src/components/standalone/wireguard/WireguardPeerTunnelList.vue
@@ -178,7 +178,7 @@ useIntervalFn(
           </template>
           {{ t('standalone.wireguard_peers.import_peer_tunnel') }}
         </NeButton>
-        <NeButton kind="secondary" @click="showTunnelDrawer = true">
+        <NeButton kind="tertiary" @click="showTunnelDrawer = true">
           <template #prefix>
             <FontAwesomeIcon :icon="faCirclePlus" aria-hidden="true" class="size-4" />
           </template>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -716,7 +716,7 @@
         "add_key_button": "Add key",
         "unnamed_key": "Unnamed key",
         "add_new_ssh_key": {
-          "label": "Add new SSH key",
+          "label": "New SSH key",
           "placeholder": "Paste SSH key here..."
         },
         "delete_key_modal": {

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -540,7 +540,7 @@
         "add_key_button": "Aggiungi chiave",
         "unnamed_key": "Chiave senza nome",
         "add_new_ssh_key": {
-          "label": "Aggiungi nuova chiave SSH",
+          "label": "Nuova chiave SSH",
           "placeholder": "Incolla qui la chiave SSH..."
         },
         "delete_key_modal": {


### PR DESCRIPTION
## Description

Minor UI/style adjustments across several standalone components to improve visual consistency and clarity of labels and buttons.

## Changes

### Components
- **NeStepper**: added an optional `labelColorClasses` prop (default `text-primary-600 dark:text-primary-500`) so the step label color can be customized.
- **NatRulesContent**: the create-rule button changed from `kind="secondary"` to `kind="primary"`
- **IpsSuppressedAlerts**: the add button now uses the `faBellSlash` icon instead of `faCirclePlus`, and its label was switched from `add_bypass` to `add_suppressed_alert` (both in the toolbar and in the empty state).
- **SshKeys**: added a "public keys" label (`ssh_keys.public_keys_label`) shown above the list when at least one key
  exists.
- **WireguardPeerTunnelList**: the add-tunnel button changed from `kind="secondary"` to `kind="tertiary"`.

### i18n
- **en.json / it.json**: renamed the SSH key label from "Add new SSH key" → "New SSH key" ("Aggiungi nuova chiave SSH" → "Nuova chiave SSH").